### PR TITLE
iconBuilder callback to build a Widget representing the specified angle

### DIFF
--- a/example/lib/example_compass.dart
+++ b/example/lib/example_compass.dart
@@ -60,7 +60,15 @@ class _ExampleCompassState extends State<ExampleCompass> {
             automaticallyHides: false,
             alignment: Alignment.centerLeft,
             padding: const EdgeInsets.all(40),
-            icon: Icon(Icons.arrow_circle_up, size: 80, color: Colors.purple),
+            iconBuilder:
+                (context, angleRadians) => Transform.rotate(
+                  angle: angleRadians,
+                  child: Icon(
+                    Icons.arrow_circle_up,
+                    size: 80,
+                    color: Colors.purple,
+                  ),
+                ),
           ),
         ],
       ),

--- a/lib/arcgis_maps_toolkit.dart
+++ b/lib/arcgis_maps_toolkit.dart
@@ -26,5 +26,5 @@ import 'package:flutter/material.dart';
 part 'src/authenticator/authenticator.dart';
 part 'src/authenticator/authenticator_login.dart';
 part 'src/compass/compass.dart';
-part 'src/compass/needle_painter.dart';
+part 'src/compass/compass_needle_painter.dart';
 part 'src/template_widget.dart';

--- a/lib/src/compass/README.md
+++ b/lib/src/compass/README.md
@@ -4,7 +4,7 @@
 
 A `Compass` is generally placed in a `Stack` on top of an `ArcGISMapView`. The `Compass` must use the same `controllerProvider` as the `ArcGISMapView`.
 
-Use `alignment` and `padding` to position the compass on the map. Set `automaticallyHides` to `false` to keep the compass visible even when the map is rotated to north (0 degrees). Set `icon` to provide your own `Widget` to represent the compass.
+Use `alignment` and `padding` to position the compass on the map. Set `automaticallyHides` to `false` to keep the compass visible even when the map is rotated to north (0 degrees). Set `iconBuilder` to provide your own `Widget` to represent the compass.
 
 ```dart
   @override
@@ -20,7 +20,15 @@ Use `alignment` and `padding` to position the compass on the map. Set `automatic
             automaticallyHides: false,
             alignment: Alignment.centerLeft,
             padding: const EdgeInsets.all(40),
-            icon: Icon(Icons.arrow_circle_up, size: 80, color: Colors.purple),
+            iconBuilder:
+                (context, angleRadians) => Transform.rotate(
+                  angle: angleRadians,
+                  child: Icon(
+                    Icons.arrow_circle_up,
+                    size: 80,
+                    color: Colors.purple,
+                  ),
+                ),
           ),
         ],
       ),

--- a/lib/src/compass/compass_needle_painter.dart
+++ b/lib/src/compass/compass_needle_painter.dart
@@ -17,9 +17,12 @@
 part of '../../arcgis_maps_toolkit.dart';
 
 /// A [CustomPainter] that paints a classic compass needle.
-class NeedlePainter extends CustomPainter {
-  /// Constructs a [NeedlePainter].
-  NeedlePainter();
+class CompassNeedlePainter extends CustomPainter {
+  /// Constructs a [CompassNeedlePainter] with the needle rotated by `angleRadians`.
+  CompassNeedlePainter(this.angleRadians);
+
+  /// The angle (in radians) at which the needle is rotated.
+  final double angleRadians;
 
   static final _bronzePaint =
       Paint()..color = const Color.fromARGB(255, 241, 169, 59);
@@ -41,6 +44,9 @@ class NeedlePainter extends CustomPainter {
     // Center and normalize the canvas as [-0.5, -0.5] to [0.5, 0.5].
     canvas.translate(size.width / 2, size.height / 2);
     canvas.scale(size.width, size.height);
+
+    // Rotate to the specified angle (in radians).
+    canvas.rotate(angleRadians);
 
     // Scale down the needle to 60% of the available space.
     canvas.scale(0.6);
@@ -80,5 +86,7 @@ class NeedlePainter extends CustomPainter {
   }
 
   @override
-  bool shouldRepaint(covariant CustomPainter oldDelegate) => false;
+  bool shouldRepaint(covariant CustomPainter oldDelegate) {
+    return (oldDelegate as CompassNeedlePainter).angleRadians != angleRadians;
+  }
 }


### PR DESCRIPTION
The initial implementation allowed client code to specify a Widget to use as the compass, which we would then rotate to the proper angle. This has been reworked so that now the client code has the option to specify an "iconBuilder" callback, which is passed the compass angle. The callback then returns a Widget that represents the given angle. This gives the client code flexibility to present the compass however they'd like.