### PR TITLE
Fields styling

### DIFF
--- a/lib/src/popups/attachments_popup_element_view.dart
+++ b/lib/src/popups/attachments_popup_element_view.dart
@@ -261,9 +261,7 @@ class _PopupAttachmentViewInListState
       title: Text(widget.popupAttachment.name),
       subtitle: Text(
         widget.popupAttachment.size.toSizeString,
-        style: Theme.of(
-          context,
-        ).textTheme.titleSmall?.copyWith(color: Colors.grey),
+        style: Theme.of(context).textTheme.titleSmall,
       ),
       trailing:
           filePath == null

--- a/lib/src/popups/fields_popup_element_view.dart
+++ b/lib/src/popups/fields_popup_element_view.dart
@@ -85,12 +85,7 @@ class _FieldRow extends StatelessWidget {
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          Text(
-            field.label,
-            style: Theme.of(
-              context,
-            ).textTheme.titleSmall?.copyWith(color: Colors.grey),
-          ),
+          Text(field.label, style: Theme.of(context).textTheme.titleSmall),
           _FormattedValueText(formattedValue: field.formattedValue),
           const Divider(color: Colors.grey, height: 2, thickness: 1),
         ],
@@ -121,9 +116,8 @@ class _FormattedValueText extends StatelessWidget {
           padding: const EdgeInsets.only(bottom: 4),
           child: Text(
             'View',
-            style: TextStyle(
+            style: Theme.of(context).textTheme.labelMedium?.copyWith(
               color: Theme.of(context).primaryColor,
-              decoration: TextDecoration.underline,
             ),
           ),
         ),

--- a/lib/src/popups/popup_views/popup_element_header.dart
+++ b/lib/src/popups/popup_views/popup_element_header.dart
@@ -29,12 +29,7 @@ class _PopupElementHeader extends StatelessWidget {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        Text(
-          title,
-          style: Theme.of(
-            context,
-          ).textTheme.titleSmall?.copyWith(color: Colors.grey),
-        ),
+        Text(title, style: Theme.of(context).textTheme.titleSmall),
         if (description.isNotEmpty)
           Text(description, style: Theme.of(context).textTheme.bodyMedium),
       ],

--- a/lib/src/popups/theme/theme_data.dart
+++ b/lib/src/popups/theme/theme_data.dart
@@ -37,19 +37,16 @@ ThemeData popupViewThemeData = ThemeData(
       fontWeight: FontWeight.bold,
       color: Colors.grey,
     ),
-
     titleSmall: TextStyle(
       fontSize: 16,
       fontWeight: FontWeight.w500,
-      color: Colors.black,
+      color: Colors.grey,
     ),
-
     labelMedium: TextStyle(
       fontSize: 16,
       fontWeight: FontWeight.w400,
       color: Colors.black,
     ),
-
     bodyMedium: TextStyle(
       fontSize: 14,
       fontWeight: FontWeight.w400,


### PR DESCRIPTION
This PR reviews and updates the styling for the fields section of the PopupView. i.e. list with a field label, field data and divider. There was a straightforward knock on here to the section titles for attachments and popup element header, so I did the same update there within this PR.

- field label -> left as `titleSmall` but removed the hardcoded color. Did the same attachment subtitle and popup element header.
- Added the grey color to our `theme_data` we're providing. Otherwise these headings can now be customized by a developer if desired.
- Also amended the links in the fields section (always labeled "View") to a) remove underline decoration and b) set to a specific label type, but keeping the setting of the color to the theme's primary color. This could then be used by the developer to integrate application level styling, or, apply a specific primary color for the popup view.
- Note: the divider is left with a hardcoded color deliberately. It felt like a more functional than a stylistic divider.
