### PR TITLE
Hide divider lines expansion tile

### DIFF
--- a/lib/src/popups/attachments_popup_element_view.dart
+++ b/lib/src/popups/attachments_popup_element_view.dart
@@ -65,31 +65,36 @@ class _AttachmentsPopupElementViewState
               ),
             );
           }
-          return ExpansionTile(
-            title: _PopupElementHeader(
-              title:
-                  widget.attachmentsElement.title.isEmpty
-                      ? 'Attachments'
-                      : widget.attachmentsElement.title,
-              description: widget.attachmentsElement.description,
-            ),
-            initiallyExpanded: isExpanded,
-            onExpansionChanged: (expanded) {
-              setState(() => isExpanded = expanded);
-            },
-            expandedCrossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              SizedBox(
-                height: 200,
-                child:
-                    widget.attachmentsElement.attachments.isEmpty
-                        ? const Center(child: Text('No attachments available'))
-                        : widget.attachmentsElement.displayType ==
-                            PopupAttachmentsDisplayType.preview
-                        ? _buildGridView()
-                        : _buildListView(),
+          return Theme(
+            data: Theme.of(context).copyWith(dividerColor: Colors.transparent),
+            child: ExpansionTile(
+              title: _PopupElementHeader(
+                title:
+                    widget.attachmentsElement.title.isEmpty
+                        ? 'Attachments'
+                        : widget.attachmentsElement.title,
+                description: widget.attachmentsElement.description,
               ),
-            ],
+              initiallyExpanded: isExpanded,
+              onExpansionChanged: (expanded) {
+                setState(() => isExpanded = expanded);
+              },
+              expandedCrossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                SizedBox(
+                  height: 200,
+                  child:
+                      widget.attachmentsElement.attachments.isEmpty
+                          ? const Center(
+                            child: Text('No attachments available'),
+                          )
+                          : widget.attachmentsElement.displayType ==
+                              PopupAttachmentsDisplayType.preview
+                          ? _buildGridView()
+                          : _buildListView(),
+                ),
+              ],
+            ),
           );
         },
       ),

--- a/lib/src/popups/fields_popup_element_view.dart
+++ b/lib/src/popups/fields_popup_element_view.dart
@@ -54,21 +54,24 @@ class _FieldsPopupElementViewState extends State<_FieldsPopupElementView> {
   Widget build(BuildContext context) {
     return Card(
       margin: const EdgeInsets.all(8),
-      child: ExpansionTile(
-        title: _PopupElementHeader(
-          title:
-              widget.fieldsElement.title.isEmpty
-                  ? 'Fields'
-                  : widget.fieldsElement.title,
-          description: widget.fieldsElement.description,
+      child: Theme(
+        data: Theme.of(context).copyWith(dividerColor: Colors.transparent),
+        child: ExpansionTile(
+          title: _PopupElementHeader(
+            title:
+                widget.fieldsElement.title.isEmpty
+                    ? 'Fields'
+                    : widget.fieldsElement.title,
+            description: widget.fieldsElement.description,
+          ),
+          initiallyExpanded: isExpanded,
+          onExpansionChanged: (expanded) {
+            setState(() => isExpanded = expanded);
+          },
+          expandedCrossAxisAlignment: CrossAxisAlignment.start,
+          children:
+              displayFields.map((field) => _FieldRow(field: field)).toList(),
         ),
-        initiallyExpanded: isExpanded,
-        onExpansionChanged: (expanded) {
-          setState(() => isExpanded = expanded);
-        },
-        expandedCrossAxisAlignment: CrossAxisAlignment.start,
-        children:
-            displayFields.map((field) => _FieldRow(field: field)).toList(),
       ),
     );
   }

--- a/lib/src/popups/media_popup_element_view.dart
+++ b/lib/src/popups/media_popup_element_view.dart
@@ -47,24 +47,27 @@ class _MediaPopupElementViewState extends State<_MediaPopupElementView> {
     if (displayableMediaCount > 0) {
       return Card(
         margin: const EdgeInsets.all(8),
-        child: ExpansionTile(
-          title: _PopupElementHeader(
-            title:
-                widget.mediaElement.title.isEmpty
-                    ? 'Media'
-                    : widget.mediaElement.title,
-            description: widget.mediaElement.description,
-          ),
-          initiallyExpanded: isExpanded,
-          onExpansionChanged: (expanded) {
-            setState(() => isExpanded = expanded);
-          },
-          children: [
-            _PopupMediaView(
-              popupMedia: widget.mediaElement.media,
-              displayableMediaCount: displayableMediaCount,
+        child: Theme(
+          data: Theme.of(context).copyWith(dividerColor: Colors.transparent),
+          child: ExpansionTile(
+            title: _PopupElementHeader(
+              title:
+                  widget.mediaElement.title.isEmpty
+                      ? 'Media'
+                      : widget.mediaElement.title,
+              description: widget.mediaElement.description,
             ),
-          ],
+            initiallyExpanded: isExpanded,
+            onExpansionChanged: (expanded) {
+              setState(() => isExpanded = expanded);
+            },
+            children: [
+              _PopupMediaView(
+                popupMedia: widget.mediaElement.media,
+                displayableMediaCount: displayableMediaCount,
+              ),
+            ],
+          ),
         ),
       );
     } else {


### PR DESCRIPTION
By default, an ExpansionTile has these dividers at the top and bottom. I think they're a bit strange and don't look aesthetically pleasing. This seems to be a common request and there was a Flutter issue that was put down to a styling thing rather than a "bug". 

It seems like the best way to workaround is to wrap the `ExpansionTile` in a `Theme` widget and then just override the divider color through the theme. It certainly looks tidier but open to thoughts in whether there is a better way of doing this.