### PR TITLE
Cs/Remove Snapshot Error

### DIFF
--- a/lib/src/popups/attachments_popup_element_view.dart
+++ b/lib/src/popups/attachments_popup_element_view.dart
@@ -61,7 +61,12 @@ class _AttachmentsPopupElementViewState
               return const Center(child: CircularProgressIndicator());
             } else if (snapshot.hasError) {
               return Center(
-                child: Text('Failed to load attachments: ${snapshot.error}'),
+                child: Text(
+                  'Unable to load attachments.',
+                  style: Theme.of(
+                    context,
+                  ).textTheme.bodyLarge?.copyWith(color: Colors.red),
+                ),
               );
             }
             return Theme(

--- a/lib/src/popups/popup_view.dart
+++ b/lib/src/popups/popup_view.dart
@@ -56,6 +56,8 @@ class PopupView extends StatelessWidget {
             const Divider(color: Colors.grey, height: 2, thickness: 2),
             Expanded(
               child: FutureBuilder(
+                // Evaluate the popup expressions asynchronously, 
+                // it needs to be done before displaying the popup elements.
                 future: popup.evaluateExpressions(),
                 builder: (context, snapshot) {
                   if (snapshot.connectionState == ConnectionState.done) {
@@ -63,8 +65,8 @@ class PopupView extends StatelessWidget {
                   } else if (snapshot.hasError) {
                     return Center(
                       child: Text(
-                        'Error: ${snapshot.error}',
-                        style: const TextStyle(color: Colors.red),
+                        'Unable to evaluate popup expressions.',
+                        style: themeData.textTheme.bodyLarge?.copyWith(color: Colors.red),
                       ),
                     );
                   } else {


### PR DESCRIPTION
- Remove showing the `snapshot.errors` to the end users; it doesn't mean too much to them.