### PR TITLE
rename "extentSymbol" to "symbol"

### DIFF
--- a/lib/src/overview_map/README.md
+++ b/lib/src/overview_map/README.md
@@ -4,7 +4,7 @@
 
 An `OverviewMap` is generally placed in a `Stack` on top of an `ArcGISMapView`. The `OverviewMap` must use the same `controllerProvider` as the `ArcGISMapView`.
 
-Use `alignment` and `padding` to position the overview map on the target map. The overview map's scale will be set to the scale of the target map multiplied by the `scaleFactor`. The `extentSymbol` will be used to draw the visible area of the target map on the overview map. By default, it is a 1 pixel red outline. Use `map` to specify the `ArcGISMap` used by the overview map. By default, the map uses the ArcGIS Topographic basemap style.
+Use `alignment` and `padding` to position the overview map on the target map. The overview map's scale will be set to the scale of the target map multiplied by the `scaleFactor`. The `symbol` will be used to draw the visible area of the target map on the overview map. By default, it is a 1 pixel red outline. Use `map` to specify the `ArcGISMap` used by the overview map. By default, the map uses the ArcGIS Topographic basemap style.
 
 Set `containerBuilder` to provide your own `Widget` to customize the presentation of the overview map. The returned `Widget` must include the provided `child`, which will be the overview map itself. By default, the overview map will be 150x100 pixels with a 1 pixel black border.
 

--- a/lib/src/overview_map/overview_map.dart
+++ b/lib/src/overview_map/overview_map.dart
@@ -27,7 +27,7 @@ class OverviewMap extends StatefulWidget {
     this.alignment = Alignment.topRight,
     this.padding = const EdgeInsets.all(10),
     this.scaleFactor = 25,
-    this.extentSymbol,
+    this.symbol,
     this.map,
     this.containerBuilder,
   });
@@ -49,7 +49,7 @@ class OverviewMap extends StatefulWidget {
       alignment: alignment,
       padding: padding,
       scaleFactor: scaleFactor,
-      extentSymbol: symbol,
+      symbol: symbol,
       map: map,
       containerBuilder: containerBuilder,
     );
@@ -72,7 +72,7 @@ class OverviewMap extends StatefulWidget {
       alignment: alignment,
       padding: padding,
       scaleFactor: scaleFactor,
-      extentSymbol: symbol,
+      symbol: symbol,
       map: map,
       containerBuilder: containerBuilder,
     );
@@ -103,7 +103,7 @@ class OverviewMap extends StatefulWidget {
   /// The symbol used to represent the current viewpoint.
   /// - For MapView: a [SimpleFillSymbol]
   /// - For SceneView: a [SimpleMarkerSymbol]
-  final ArcGISSymbol? extentSymbol;
+  final ArcGISSymbol? symbol;
 
   /// The map to use as the overview map.
   ///
@@ -140,8 +140,7 @@ class _OverviewMapState extends State<OverviewMap> {
     _controller = widget.controllerProvider();
 
     // Assign the symbol or use a default based on controller type.
-    _extentGraphic.symbol =
-        widget.extentSymbol ?? _defaultSymbolFor(_controller);
+    _extentGraphic.symbol = widget.symbol ?? _defaultSymbolFor(_controller);
 
     _overviewController.graphicsOverlays.add(
       GraphicsOverlay()..graphics.add(_extentGraphic),


### PR DESCRIPTION
The "extentSymbol" property on OverviewMap is really only an "extent" in the Map case. In the Scene case, it's a single point. So we rename it to just "symbol" so it makes sense for both Map and Scene.
