### PR TITLE
update arcgis_maps dependency version

### DIFF
--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -7,7 +7,7 @@ environment:
   sdk: '>=3.8.1 <4.0.0'
 
 dependencies:
-  arcgis_maps: ^200.7.0
+  arcgis_maps: ^200.8.0
   arcgis_maps_toolkit:
     path: ../
   flutter:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -14,7 +14,7 @@ environment:
   flutter: '>=3.32.2'
 
 dependencies:
-  arcgis_maps: ^200.7.0
+  arcgis_maps: ^200.8.0
   file_picker: ^10.2.0
   fl_chart: ^1.0.0
   flutter:


### PR DESCRIPTION
Move the dependency on arcgis_maps from 200.7 to 200.8. This is necessary due to new types in 200.8, such as Popup.