### PR TITLE
This Icon can no longer be const

### DIFF
--- a/example/lib/example_compass_custom.dart
+++ b/example/lib/example_compass_custom.dart
@@ -69,15 +69,14 @@ class _ExampleCompassCustomState extends State<ExampleCompassCustom> {
             size: 80,
             // Optionally, apply a custom icon builder to style the icon representing the compass.
             // See the other examples for the default compass style.
-            iconBuilder:
-                (context, size, angleRadians) => Transform.rotate(
-                  angle: angleRadians,
-                  child: const Icon(
-                    Icons.arrow_circle_up,
-                    size: size,
-                    color: Colors.purple,
-                  ),
-                ),
+            iconBuilder: (context, size, angleRadians) => Transform.rotate(
+              angle: angleRadians,
+              child: Icon(
+                Icons.arrow_circle_up,
+                size: size,
+                color: Colors.purple,
+              ),
+            ),
           ),
         ],
       ),


### PR DESCRIPTION
The recent change to add a "size" parameter has broken the example app. This particular `Icon` can no longer be `const`, because `size` is now a parameter and can change.