### PR TITLE
Follow the same pattern as arcgis_maps for placeholder values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.0.1
+## 0.0.0+0 # version will be set during export in ci/stamp_toolkit.sh
 
 * First release of ArcGIS Maps SDK for Flutter Toolkit
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: arcgis_maps_toolkit
 description: ArcGIS Maps SDK for Flutter Toolkit contains ready-made widgets to simplify the development of mapping and GIS apps with Flutter.
-version: 0.0.1
+version: 0.0.0+0 # version will be set during export in ci/stamp_toolkit.sh
 homepage: https://developers.arcgis.com/flutter/
 topics:
   - map


### PR DESCRIPTION
As part of the export process, we stamp the daily build number into `pubspec.yaml` and `CHANGELOG.md`. Here we make these placeholders consistent with what we do for `arcgis_maps` package. Part of which is adding a comment right inline so that people don't manually change these values.