### PR TITLE
compile toolkit example app with SDK 36

### DIFF
--- a/example/android/app/build.gradle.kts
+++ b/example/android/app/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
 
 android {
     namespace = "com.esri.arcgis_maps_toolkit_example"
-    compileSdk = flutter.compileSdkVersion
+    compileSdk = 36
     ndkVersion = "27.0.12077973"
 
     compileOptions {


### PR DESCRIPTION
Compile the toolkit example app with compileSdk = 36 (the latest).