### PR TITLE
Use the more efficient orientationOf

### DIFF
--- a/lib/src/popups/popup_views/pie_chart.dart
+++ b/lib/src/popups/popup_views/pie_chart.dart
@@ -33,7 +33,7 @@ class _PopupPieChart extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final radius = MediaQuery.of(context).orientation == Orientation.portrait
+    final radius = MediaQuery.orientationOf(context) == Orientation.portrait
         ? MediaQuery.sizeOf(context).width / 3
         : MediaQuery.sizeOf(context).height / 3;
     return GestureDetector(


### PR DESCRIPTION
`MediaQuery.of(context)` is inefficient, so we use `orientationOf` instead.