### PR TITLE
adopt "strict-casts" language mode

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,1 +1,13 @@
 include: linter_rules.yaml
+
+analyzer:
+  errors:
+    close_sinks: warning
+    missing_required_param: error
+    missing_return: error
+    record_literal_one_positional_no_trailing_comma: error
+    collection_methods_unrelated_type: warning
+    unrelated_type_equality_checks: error
+
+  language:
+    strict-casts: true


### PR DESCRIPTION
Turn on the "strict-casts" language mode to require ourselves to make casts explicit rather than implicitly casting from `dynamic`. Also adopt the other "analyzer/error" settings we use internally.

This didn't require any changes to the toolkit code.
