### PR TITLE
Adopt the "strict-inference" language mode

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -11,3 +11,4 @@ analyzer:
 
   language:
     strict-casts: true
+    strict-inference: true

--- a/lib/src/authenticator/authenticator.dart
+++ b/lib/src/authenticator/authenticator.dart
@@ -202,7 +202,7 @@ class _AuthenticatorState extends State<Authenticator>
 
   void _tokenLogin(ArcGISAuthenticationChallenge challenge) {
     // Show an _AuthenticatorLogin dialog, which will answer the challenge.
-    showDialog(
+    showDialog<void>(
       context: context,
       builder: (context) =>
           _AuthenticatorLogin(challenge: _ArcGISLoginChallenge(challenge)),
@@ -216,7 +216,7 @@ class _AuthenticatorState extends State<Authenticator>
     switch (challenge) {
       case ServerTrustAuthenticationChallenge():
         // Show an _AuthenticatorTrust dialog, which will answer the challenge.
-        await showDialog(
+        await showDialog<void>(
           context: context,
           builder: (context) => _AuthenticatorTrust(challenge: challenge),
         );
@@ -224,7 +224,7 @@ class _AuthenticatorState extends State<Authenticator>
       case DigestAuthenticationChallenge():
       case NtlmAuthenticationChallenge():
         // Show an _AuthenticatorLogin dialog, which will answer the challenge.
-        await showDialog(
+        await showDialog<void>(
           context: context,
           builder: (context) =>
               _AuthenticatorLogin(challenge: _NetworkLoginChallenge(challenge)),
@@ -267,7 +267,7 @@ class _AuthenticatorState extends State<Authenticator>
 
     // Show a dialog to prompt the user for the certificate file's password, which
     // will answer the challenge.
-    await showDialog(
+    await showDialog<void>(
       context: context,
       builder: (context) =>
           _AuthenticatorCertificatePassword(challenge: challenge, file: file),

--- a/lib/src/popups/attachments_popup_element_view.dart
+++ b/lib/src/popups/attachments_popup_element_view.dart
@@ -211,7 +211,7 @@ class _PopupAttachmentViewInGalleryState
           }
         } else {
           if (attachment.contentType.startsWith('image') && mounted) {
-            await showDialog(
+            await showDialog<void>(
               context: context,
               builder: (context) =>
                   _DetailsScreenImageDialog(filePath: filePath!),
@@ -377,7 +377,7 @@ class _PopupAttachmentViewInListState
           }
         } else {
           if (widget.popupAttachment.contentType.startsWith('image')) {
-            showDialog(
+            showDialog<void>(
               context: context,
               builder: (context) =>
                   _DetailsScreenImageDialog(filePath: filePath!),

--- a/lib/src/popups/popup_views/bar_chart.dart
+++ b/lib/src/popups/popup_views/bar_chart.dart
@@ -39,7 +39,7 @@ class _PopupBarChart extends StatelessWidget {
     return GestureDetector(
       onTap: () {
         Navigator.of(context).push(
-          MaterialPageRoute(
+          MaterialPageRoute<void>(
             builder: (context) => _BarChartDetailView(
               popupMedia: popupMedia,
               // Bar Chart should be interactive in detail view.

--- a/lib/src/popups/popup_views/image_media_view.dart
+++ b/lib/src/popups/popup_views/image_media_view.dart
@@ -41,7 +41,7 @@ class _ImageMediaViewState extends State<_ImageMediaView> {
         onTap: () {
           if (isShowingDetailReady) {
             Navigator.of(context).push(
-              MaterialPageRoute(
+              MaterialPageRoute<void>(
                 builder: (context) => _MediaDetailView(
                   popupMedia: widget.popupMedia,
                   onClose: () {

--- a/lib/src/popups/popup_views/line_chart.dart
+++ b/lib/src/popups/popup_views/line_chart.dart
@@ -36,7 +36,7 @@ class _PopupLineChart extends StatelessWidget {
     return GestureDetector(
       onTap: () {
         Navigator.of(context).push(
-          MaterialPageRoute(
+          MaterialPageRoute<void>(
             builder: (context) => _LineChartDetailView(
               popupMedia: popupMedia,
               // Line Chart should be interactive in detail view.

--- a/lib/src/popups/popup_views/pie_chart.dart
+++ b/lib/src/popups/popup_views/pie_chart.dart
@@ -39,7 +39,7 @@ class _PopupPieChart extends StatelessWidget {
     return GestureDetector(
       onTap: () {
         Navigator.of(context).push(
-          MaterialPageRoute(
+          MaterialPageRoute<void>(
             builder: (context) => _PieChartDetailView(
               popupMedia: popupMedia,
               chartData: chartData,


### PR DESCRIPTION
The "strict-inference" language mode requires all inferred types to be unambiguous. This prompts us to understand the types of objects we're creating and makes our intent more explicit.
