### PR TITLE
Adopt the "strict-raw-types" language mode

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -12,3 +12,4 @@ analyzer:
   language:
     strict-casts: true
     strict-inference: true
+    strict-raw-types: true


### PR DESCRIPTION
This "strict-raw-types" language mode disallows the use of raw generic types (i.e., using a generic type without type arguments). This requires us to specify the generic types, such as `Future` must now be `Future<dynamic>` or `Future<void>`, etc.

Here in the toolkit, there were no changes required by this mode.