### PR TITLE
Upgrade to Kotlin 2.2.0

### DIFF
--- a/example/android/settings.gradle.kts
+++ b/example/android/settings.gradle.kts
@@ -19,7 +19,7 @@ pluginManagement {
 plugins {
     id("dev.flutter.flutter-plugin-loader") version "1.0.0"
     id("com.android.application") version "8.7.0" apply false
-    id("org.jetbrains.kotlin.android") version "1.9.0" apply false
+    id("org.jetbrains.kotlin.android") version "2.2.0" apply false
 }
 
 include(":app")


### PR DESCRIPTION
The latest release of Flutter issues a warning that support for Kotlin 2.0.0 is being deprecated. Thus we move up to Kotlin 2.2.0.