### PR TITLE
Pin fl_chart to previous version until we can update to the latest Flutter

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -17,7 +17,7 @@ environment:
 dependencies:
   arcgis_maps: ^300.0.0
   file_picker: ^10.2.0
-  fl_chart: ^1.0.0
+  fl_chart: 1.0.0
   flutter:
     sdk: flutter
   open_file: ^3.5.10


### PR DESCRIPTION
The latest version of fl_chart is incompatible with the previous version of Flutter. They both depend on the vector_math package, but different versions of it. So for now, we will pin fl_chart to its previous version, and then later we can upgrade to the latest Flutter and remove the pin.