### PR TITLE
clean up icons and spacing

### DIFF
--- a/lib/src/popups/popup_views/utility_association_header.dart
+++ b/lib/src/popups/popup_views/utility_association_header.dart
@@ -32,20 +32,26 @@ class _UtilityAssociationHeader extends StatelessWidget {
       padding: const EdgeInsets.all(12),
       child: Row(
         children: [
-          // (<) back one step.
           Visibility(
             visible: !state.isHome,
-            child: IconButton(
-              onPressed: state._pop,
-              icon: const Icon(Icons.arrow_back),
-            ),
-          ),
-          // (^) exit associations.
-          Visibility(
-            visible: !state.isHome,
-            child: IconButton(
-              onPressed: state._popToRoot,
-              icon: const Icon(Icons.arrow_upward),
+            child: Padding(
+              padding: const EdgeInsets.fromLTRB(0, 0, 8, 0),
+              child: Row(
+                children: [
+                  // (<) back one step.
+                  IconButton(
+                    visualDensity: const VisualDensity(horizontal: -2),
+                    onPressed: state._pop,
+                    icon: const Icon(Icons.chevron_left),
+                  ),
+                  // (^) exit associations.
+                  IconButton(
+                    visualDensity: const VisualDensity(horizontal: -2),
+                    onPressed: state._popToRoot,
+                    icon: const Icon(Icons.keyboard_return),
+                  ),
+                ],
+              ),
             ),
           ),
           Expanded(
@@ -71,7 +77,11 @@ class _UtilityAssociationHeader extends StatelessWidget {
             ),
           ),
           // (x) close the popup.
-          IconButton(icon: const Icon(Icons.close), onPressed: state._close),
+          IconButton(
+            visualDensity: const VisualDensity(horizontal: -2),
+            icon: const Icon(Icons.close),
+            onPressed: state._close,
+          ),
         ],
       ),
     );

--- a/lib/src/popups/popup_views/utility_association_result.dart
+++ b/lib/src/popups/popup_views/utility_association_result.dart
@@ -53,7 +53,7 @@ class _UtilityAssociationResultWidget extends StatelessWidget {
         utilityAssociationResult.associatedFeature,
       ),
       trailing: isOriginFeature
-          ? const Icon(Icons.arrow_upward)
+          ? const Icon(Icons.keyboard_return)
           : const Icon(Icons.chevron_right),
     );
   }


### PR DESCRIPTION
Update to look like this:
<img width="516" height="1118" alt="icons" src="https://github.com/user-attachments/assets/99632385-0a6a-4039-9f5c-7ba11b6e0ee1" />

Uses Icons.chevron_left, Icons.keyboard_return, and a VisualDensity that shrinks the horizontal spacing a little.

chevron_left pairs well with chevron_right, which is used in a couple other places (when drilling down into related associations).

We want to maintain the minimum recommended size for tappable regions, so we probably shouldn't try to compact them any further.