### PR TITLE
Example app: Fix fl_chart dependency version to resolve conflict

### DIFF
--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -18,5 +18,8 @@ dev_dependencies:
   flutter_test:
     sdk: flutter
 
+dependency_overrides:
+  fl_chart: 1.0.0
+
 flutter:
   uses-material-design: true


### PR DESCRIPTION
- This PR is into `main`.
- Currently the example app on the `main` branch will not compile with our minimum system requirement of Flutter 3.32.x
- Fixing the version of `fl_chart` (introduced by our toolkit) resolves this. The example also continues to run on 3.35.x as well.
- We should remove this once we raise our minimum system requirement in a future release.