### PR TITLE
Clarify what the "jump back" button does

### DIFF
--- a/lib/src/popups/popup_view.dart
+++ b/lib/src/popups/popup_view.dart
@@ -111,11 +111,15 @@ class _PopupViewState extends State<PopupView> {
     );
   }
 
-  // Navigate to a pop-up view with the specified key, removing other pages.
-  void _popupWithKey(String key) {
-    setState(() {
-      _pages.removeWhere((page) => page.key != ValueKey(key));
-    });
+  // Navigate to the pop-up view with the specified key, removing later pages.
+  void _popToKey(String key) {
+    final valueKey = ValueKey(key);
+    final index = _pages.indexWhere((page) => page.key == valueKey);
+    if (index != -1 && index < _pages.length - 1) {
+      setState(() {
+        _pages.removeRange(index + 1, _pages.length);
+      });
+    }
   }
 
   // Push a new page onto the navigation stack.

--- a/lib/src/popups/popup_views/utility_association_result.dart
+++ b/lib/src/popups/popup_views/utility_association_result.dart
@@ -151,12 +151,11 @@ void _navigateToAssociationPopupPage(
   ArcGISFeature feature,
 ) {
   final state = context.findAncestorStateOfType<_PopupViewState>();
-  // If the popup for this feature is the one that is the original one
-  // on the navigation stack, pop back to it.
-  final key = _getPopupViewKey(feature);
   if (state != null) {
+    // If the popup for this feature is already on the navigation stack, pop back to it.
+    final key = _getPopupViewKey(feature);
     if (state._isExistingPopupPage(key)) {
-      state._popupWithKey(key);
+      state._popToKey(key);
     } else {
       // otherwise, show a new PopupView.
       final popup = feature.toPopup();


### PR DESCRIPTION
In this screenshot, we got here by starting at the "SubTransmission" page, drilling down to "Substation", then going in a circle so that we are almost at "Substation" again.

<img width="426" height="923" alt="Simulator Screenshot - iPhone 15 Pro Max iOS17 2 - 2025-10-27 at 16 30 20" src="https://github.com/user-attachments/assets/7f6a88dc-5a58-452c-9a09-ea48f4029abc" />

The "return" button in the header is supposed to jump back to the original item, which in this case is "SubTransmission". And that's working all fine.

There's a second "return" button here as well, down at the bottom right of the content pane. Normally this is a "drill down" (right chevron) button, but it turns into this "return" button when it would take you to an item that you've already navigated through. When that happens, it is supposed to step you back as many steps as necessary to get back to that page. In this case, it's the "Substation" page, which is 3 steps back.

The bug here is that it was removing from the stack all pages except the one you were navigating to. But that's not what we want -- we only want to drop the pages that are above the page you're navigating to. That's what this fix does -- it finds the page you're looking for, and removes all the pages after it.