### PR TITLE
Remove "repository:" from pubspec.yaml

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,6 @@ name: arcgis_maps_toolkit
 description: ArcGIS Maps SDK for Flutter Toolkit contains ready-made widgets to simplify the development of mapping and GIS apps with Flutter.
 version: 0.0.0+0 # version will be set during export in ci/stamp_toolkit.sh
 homepage: https://developers.arcgis.com/flutter/
-repository: https://github.com/Esri/arcgis-maps-sdk-flutter-toolkit/
 topics:
   - map
   - location


### PR DESCRIPTION
pub.dev runs the "pana" tool to determine a package's "score". Currently we get 150/160, with the missing points due to our "repository:" setting in pubspec.yaml. We have it set to point at our github repository, but we don't actually publish directly from there -- we export the repo and run a script to adjust some values, including the relevant bits in pubspec.yaml, and then publish that. Because we have to make those adjustments, "pana" complains that our repository isn't correct -- we have a "publish_to: none" setting, and our "version:" setting doesn't match.

The fix here is to just remove the "repository:" line. It's not providing us any benefit -- pub.dev won't make use of it because it doesn't validate correctly. We can link to the github repo elsewhere, such as in the README.md, if we want to get a link from pub.dev to the github repo.