### PR TITLE
Add URLs to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ API reference for each of the toolkit components can be found via the ArcGIS Map
 
 # Additional resources
 
+* View ArcGIS Maps SDK for Flutter Toolkit on: [pub.dev]((https://pub.dev/packages/arcgis_maps_toolkit)) | [Github](https://github.com/ArcGIS/arcgis-maps-sdk-flutter-toolkit)
 * New to ArcGIS? Explore our documentation: [Guide](https://developers.arcgis.com/flutter) | [API Reference](https://links.esri.com/flutter-api-ref)
 * Got a question? Ask the community on our [forum](https://links.esri.com/flutter-community).
 


### PR DESCRIPTION
Since we have removed the repository from pubspec.yaml with us not deploying in this way, I think we can enhance our readme so that it links out to both pub.dev from Github, and Github from pub.dev.