### PR TITLE
Control the style of the search field

### DIFF
--- a/lib/src/popups/popup_views/utility_association_result_selector.dart
+++ b/lib/src/popups/popup_views/utility_association_result_selector.dart
@@ -56,10 +56,7 @@ class _AssociationResultSelectionPageState
                 children: [
                   TextField(
                     controller: _searchController,
-                    decoration: const InputDecoration(
-                      labelText: 'Search',
-                      border: OutlineInputBorder(),
-                    ),
+                    decoration: const InputDecoration(labelText: 'Search'),
                   ),
                   Expanded(
                     child: ValueListenableBuilder<TextEditingValue>(

--- a/lib/src/popups/theme/theme_data.dart
+++ b/lib/src/popups/theme/theme_data.dart
@@ -97,4 +97,14 @@ ThemeData _popupViewThemeData = ThemeData(
   iconTheme: const IconThemeData(color: Colors.grey),
   // Used by fullscreen dialog e.g. when an image or chart is tapped.
   appBarTheme: const AppBarTheme(),
+  inputDecorationTheme: const InputDecorationThemeData(
+    labelStyle: TextStyle(color: Colors.black),
+    focusedBorder: OutlineInputBorder(),
+    border: OutlineInputBorder(),
+  ),
+  textSelectionTheme: TextSelectionThemeData(
+    selectionColor: Colors.blue[200],
+    cursorColor: Colors.blue,
+    selectionHandleColor: Colors.blue,
+  ),
 );


### PR DESCRIPTION
We want to control the style of the PopupView so that it stays the same regardless of any Theme set in the surrounding app. The last remaining piece was the "Search" field -- the selection background color and the border style are now fixed.

<img width="323" height="476" alt="Simulator Screenshot - iPhone 15 Pro Max iOS17 2 - 2025-11-04 at 13 21 33" src="https://github.com/user-attachments/assets/f1a1ac1e-97f6-449d-95a0-05ed2a4d91bd" />
