### PR TITLE
only show the close button when onClose is set

### DIFF
--- a/lib/src/popups/popup_view.dart
+++ b/lib/src/popups/popup_view.dart
@@ -55,7 +55,10 @@ class PopupView extends StatefulWidget {
   /// Creates a [PopupView] widget to display a [Popup] with optional `onClose` callback.
   const PopupView({required this.popup, this.onClose, super.key});
 
-  /// An optional callback function that is called when the [PopupView] is closed. By default, it closes the view.
+  /// An optional callback function that is called when the "close" button is tapped.
+  ///
+  /// The callback should handle dismissing the containing widget or perform the necessary state changes to close the pop-up.
+  /// If not provided, the close button will not be shown.
   final VoidCallback? onClose;
 
   /// The [Popup] object to be displayed.
@@ -140,6 +143,9 @@ class _PopupViewState extends State<PopupView> {
     // At root: treat as close request instead of popping (avoids empty pages list).
     widget.onClose?.call();
   }
+
+  // Whether the PopupView has an onClose callback.
+  bool get hasClose => widget.onClose != null;
 
   // Signal to parent to close the PopupView.
   void _close() {

--- a/lib/src/popups/popup_views/utility_association_header.dart
+++ b/lib/src/popups/popup_views/utility_association_header.dart
@@ -76,11 +76,14 @@ class _UtilityAssociationHeader extends StatelessWidget {
               ],
             ),
           ),
-          // (x) close the popup.
-          IconButton(
-            visualDensity: const VisualDensity(horizontal: -2),
-            icon: const Icon(Icons.close),
-            onPressed: state._close,
+          Visibility(
+            visible: state.hasClose,
+            // (x) close the popup.
+            child: IconButton(
+              visualDensity: const VisualDensity(horizontal: -2),
+              icon: const Icon(Icons.close),
+              onPressed: state._close,
+            ),
           ),
         ],
       ),


### PR DESCRIPTION
Depending on how a client application deploys the PopupView, they may not want our built-in "close" button (the "X" in the upper right). They may have some other mechanism for closing the PopupView, like tapping outside a dialog or performing the system "back" gesture. To support that case, we now only show the "close" button if the client app supplied an "onClose" callback.