### PR TITLE
upgrade Android Gradle Plugin to 8.9.1

### DIFF
--- a/example/android/settings.gradle.kts
+++ b/example/android/settings.gradle.kts
@@ -18,7 +18,7 @@ pluginManagement {
 
 plugins {
     id("dev.flutter.flutter-plugin-loader") version "1.0.0"
-    id("com.android.application") version "8.7.0" apply false
+    id("com.android.application") version "8.9.1" apply false
     id("org.jetbrains.kotlin.android") version "2.2.0" apply false
 }
 


### PR DESCRIPTION
The version of Android Gradle Plugin used by the toolkit example app is too old for a recent update to one of the dependencies, `url_launcher_android` at version 6.3.26. Updating Android Gradle Plugin to 8.9.1 resolves the build problem.