### PR TITLE
handle IAP challenges with the Authenticator

### DIFF
--- a/example/lib/example_authenticator.dart
+++ b/example/lib/example_authenticator.dart
@@ -146,6 +146,7 @@ class _ExampleAuthenticatorState extends State<ExampleAuthenticator> {
     _mapViewController.arcGISMap = _emptyMap;
 
     await Authenticator.revokeOAuthTokens();
+    await Authenticator.invalidateIapCredentials();
     await Authenticator.clearCredentials();
 
     setState(() => _mapState = _MapState.unloaded);

--- a/lib/src/authenticator/authenticator.dart
+++ b/lib/src/authenticator/authenticator.dart
@@ -45,15 +45,15 @@ part of '../../arcgis_maps_toolkit.dart';
 ///   Widget build(BuildContext context) {
 ///     return Scaffold(
 ///       body: Authenticator(
-///         iapConfigurations: [
-///           IapConfiguration.fromJsonString(yourConfigurationJson),
-///         ],
 ///         oAuthUserConfigurations: [
 ///           OAauthUserConfiguration(
 ///             portalUri: Uri.parse('https://www.arcgis.com'),
 ///             clientId: 'YOUR-CLIENT-ID',
 ///             redirectUri: Uri.parse('YOUR-REDIRECT-URL'),
 ///           ),
+///         ],
+///         iapConfigurations: [
+///           IapConfiguration.fromJsonString(yourConfigurationJson),
 ///         ],
 ///         child: ArcGISMapView(
 ///           controllerProvider: () => _mapViewController,
@@ -89,13 +89,6 @@ class Authenticator extends StatefulWidget {
   /// recommended to make it the parent widget of an [ArcGISMapView].
   final Widget? child;
 
-  /// The list of IAP configurations to use for authenticating with an Identity-Aware Proxy (IAP).
-  ///
-  /// If an IAP challenge is received, it will be compared against the IAP configurations. If a
-  /// matching configuration is found, it will be used to prompt the user to sign in. Otherwise,
-  /// the IAP challenge will fail.
-  final List<IapConfiguration> iapConfigurations;
-
   /// The list of OAuth configurations to use for authentication.
   ///
   /// If a challenge is received that matches a configuration, the user will be
@@ -104,16 +97,13 @@ class Authenticator extends StatefulWidget {
   /// [TokenCredential].
   final List<OAuthUserConfiguration> oAuthUserConfigurations;
 
-  /// Invalidate all IAP credentials. This will launch a logout workflow in the system browser.
-  /// The returned [Future] completes when the logout process is finished.
-  static Future<void> invalidateIapCredentials() async {
-    await Future.wait(
-      ArcGISEnvironment.authenticationManager.arcGISCredentialStore
-          .getCredentials()
-          .whereType<IapCredential>()
-          .map((credential) => credential.invalidate()),
-    );
-  }
+  /// The list of IAP configurations to use for authenticating with an Identity-Aware Proxy (IAP).
+  ///
+  /// If a service is protected by an Identity-Aware Proxy (IAP), provide its [IapConfiguration] here.
+  /// If an IAP challenge is received, it will be compared against the IAP configurations. If a
+  /// matching configuration is found, it will be used to prompt the user to sign in. Otherwise,
+  /// the IAP challenge will fail.
+  final List<IapConfiguration> iapConfigurations;
 
   /// Revoke all OAuth tokens. The returned [Future] completes when all tokens
   /// have been successfully revoked.
@@ -123,6 +113,17 @@ class Authenticator extends StatefulWidget {
           .getCredentials()
           .whereType<OAuthUserCredential>()
           .map((credential) => credential.revokeToken()),
+    );
+  }
+
+  /// Invalidate all IAP credentials. This will launch a logout workflow in the system browser.
+  /// The returned [Future] completes when the logout process is finished.
+  static Future<void> invalidateIapCredentials() async {
+    await Future.wait(
+      ArcGISEnvironment.authenticationManager.arcGISCredentialStore
+          .getCredentials()
+          .whereType<IapCredential>()
+          .map((credential) => credential.invalidate()),
     );
   }
 

--- a/lib/src/authenticator/authenticator.dart
+++ b/lib/src/authenticator/authenticator.dart
@@ -75,12 +75,12 @@ part of '../../arcgis_maps_toolkit.dart';
 /// https://developers.arcgis.com/flutter/install-and-set-up/#enabling-user-authentication
 class Authenticator extends StatefulWidget {
   /// Creates an [Authenticator] widget with the optional child [Widget] and optional
-  /// `oAuthUserConfigurations`.
+  /// `oAuthUserConfigurations` and `iapConfigurations`.
   const Authenticator({
     super.key,
     this.child,
-    this.iapConfigurations = const [],
     this.oAuthUserConfigurations = const [],
+    this.iapConfigurations = const [],
   });
 
   /// An optional child widget.

--- a/lib/src/authenticator/authenticator.dart
+++ b/lib/src/authenticator/authenticator.dart
@@ -46,7 +46,7 @@ part of '../../arcgis_maps_toolkit.dart';
 ///     return Scaffold(
 ///       body: Authenticator(
 ///         iapConfigurations: [
-///          IapConfiguration.fromJsonString(yourConfigurationJson),
+///           IapConfiguration.fromJsonString(yourConfigurationJson),
 ///         ],
 ///         oAuthUserConfigurations: [
 ///           OAauthUserConfiguration(

--- a/lib/src/authenticator/authenticator.dart
+++ b/lib/src/authenticator/authenticator.dart
@@ -26,6 +26,7 @@ part of '../../arcgis_maps_toolkit.dart';
 /// * ArcGIS authentication (token and OAuth)
 /// * Integrated Windows Authentication (IWA)
 /// * Client Certificate (PKI)
+/// * Identity-Aware Proxy (IAP)
 /// * If credentials were persisted to the keychain, the authenticator will use those instead of requiring the user to re-enter credentials.
 ///
 /// ## Usage
@@ -36,11 +37,17 @@ part of '../../arcgis_maps_toolkit.dart';
 /// [Authenticator.oAuthUserConfigurations] parameter. Otherwise, the user will be prompted to
 /// sign in using a username and password to obtain a [TokenCredential].
 ///
+/// If a service is protected by an Identity-Aware Proxy (IAP), provide its [IapConfiguration]
+/// in the [Authenticator.iapConfigurations] parameter.
+///
 /// ```dart
 ///   @override
 ///   Widget build(BuildContext context) {
 ///     return Scaffold(
 ///       body: Authenticator(
+///         iapConfigurations: [
+///          IapConfiguration.fromJsonString(yourConfigurationJson),
+///         ],
 ///         oAuthUserConfigurations: [
 ///           OAauthUserConfiguration(
 ///             portalUri: Uri.parse('https://www.arcgis.com'),
@@ -72,6 +79,7 @@ class Authenticator extends StatefulWidget {
   const Authenticator({
     super.key,
     this.child,
+    this.iapConfigurations = const [],
     this.oAuthUserConfigurations = const [],
   });
 
@@ -81,6 +89,13 @@ class Authenticator extends StatefulWidget {
   /// recommended to make it the parent widget of an [ArcGISMapView].
   final Widget? child;
 
+  /// The list of IAP configurations to use for authenticating with an Identity-Aware Proxy (IAP).
+  ///
+  /// If an IAP challenge is received, it will be compared against the IAP configurations. If a
+  /// matching configuration is found, it will be used to prompt the user to sign in. Otherwise,
+  /// the IAP challenge will fail.
+  final List<IapConfiguration> iapConfigurations;
+
   /// The list of OAuth configurations to use for authentication.
   ///
   /// If a challenge is received that matches a configuration, the user will be
@@ -88,6 +103,17 @@ class Authenticator extends StatefulWidget {
   /// will be prompted to sign in using a username and password to obtain a
   /// [TokenCredential].
   final List<OAuthUserConfiguration> oAuthUserConfigurations;
+
+  /// Invalidate all IAP credentials. This will launch a logout workflow in the system browser.
+  /// The returned [Future] completes when the logout process is finished.
+  static Future<void> invalidateIapCredentials() async {
+    await Future.wait(
+      ArcGISEnvironment.authenticationManager.arcGISCredentialStore
+          .getCredentials()
+          .whereType<IapCredential>()
+          .map((credential) => credential.invalidate()),
+    );
+  }
 
   /// Revoke all OAuth tokens. The returned [Future] completes when all tokens
   /// have been successfully revoked.
@@ -164,18 +190,62 @@ class _AuthenticatorState extends State<Authenticator>
   void handleArcGISAuthenticationChallenge(
     ArcGISAuthenticationChallenge challenge,
   ) {
-    // If an OAuth configuration matches, use it. Else use token login.
-    final configuration = widget.oAuthUserConfigurations
-        .where(
-          (configuration) =>
-              configuration.canBeUsedForUri(challenge.requestUri),
-        )
-        .firstOrNull;
+    switch (challenge.type) {
+      case .iap:
+        // An IAP challenge must be handled by a matching IAP configuration, or else it fails.
+        final configuration = widget.iapConfigurations
+            .where(
+              (configuration) =>
+                  configuration.canBeUsedForUri(challenge.requestUri),
+            )
+            .firstOrNull;
 
-    if (configuration != null) {
-      _oauthLogin(challenge, configuration);
-    } else {
-      _tokenLogin(challenge);
+        if (configuration != null) {
+          _iapLogin(challenge, configuration);
+        } else {
+          challenge.continueAndFail();
+        }
+      case .oauthOrToken:
+        // An OAuth-or-token challenge is handled by the OAuth login workflow if a matching
+        // OAuth configuration is found, or else by the token login workflow.
+        final configuration = widget.oAuthUserConfigurations
+            .where(
+              (configuration) =>
+                  configuration.canBeUsedForUri(challenge.requestUri),
+            )
+            .firstOrNull;
+
+        if (configuration != null) {
+          _oauthLogin(challenge, configuration);
+        } else {
+          _tokenLogin(challenge);
+        }
+      case .token:
+        // A token challenge is handled by the token login workflow.
+        _tokenLogin(challenge);
+    }
+  }
+
+  Future<void> _iapLogin(
+    ArcGISAuthenticationChallenge challenge,
+    IapConfiguration configuration,
+  ) async {
+    try {
+      // Initiate the sign in process to the IAP server using the defined user configuration.
+      final credential = await IapCredential.create(configuration);
+
+      // Sign in was successful, so continue with the provided credential.
+      challenge.continueWithCredential(credential);
+    } on ArcGISException catch (error) {
+      // An exception occurred.
+      final e = (error.wrappedException as ArcGISException?) ?? error;
+      if (e.errorType == ArcGISExceptionType.commonUserCanceled) {
+        // User canceled.
+        challenge.cancel();
+      } else {
+        // Some other error.
+        challenge.continueAndFail();
+      }
     }
   }
 

--- a/lib/src/authenticator/authenticator.dart
+++ b/lib/src/authenticator/authenticator.dart
@@ -64,7 +64,7 @@ part of '../../arcgis_maps_toolkit.dart';
 /// ```
 ///
 /// During application sign-out, you should revoke all tokens and clear all credentials from the credential stores.
-/// Use [Authenticator.clearCredentials] and [Authenticator.revokeOAuthTokens], as required.
+/// Use [Authenticator.revokeOAuthTokens] and [Authenticator.invalidateIapCredentials] as required, then [Authenticator.clearCredentials].
 /// In addition, consider also clearing the HTTP cache, using `ArcGISEnvironment.httpClient.cache.evictAll()`, to prevent cached responses from being accessed without the credentials that were used to originally fetch them.
 ///
 /// ## More information


### PR DESCRIPTION
Support Identity-Aware Proxy (IAP) authentication challenges. These are handled similarly to OAuth challenges, in that they present a login page in the system browser. They are different in that they also have a logout process that takes you to a page in the browser. (With OAuth, you can revoke the tokens without having to send the user through a browser.)