### PR TITLE
Use the recommended "taskAffinity" setting

### DIFF
--- a/example/android/app/src/main/AndroidManifest.xml
+++ b/example/android/app/src/main/AndroidManifest.xml
@@ -27,7 +27,8 @@
         </activity>
         <activity
             android:name="com.linusu.flutter_web_auth_2.CallbackActivity"
-            android:exported="true">
+            android:exported="true"
+            android:taskAffinity="">
             <intent-filter android:label="flutter_web_auth_2">
                 <action android:name="android.intent.action.VIEW" />
                 <category android:name="android.intent.category.DEFAULT" />


### PR DESCRIPTION
With the upgrade to flutter_web_auth_2 version 5, we can now use the recommended "taskAffinity" setting.