### PR TITLE
Update to Flutter 3.41.3

### DIFF
--- a/example/ios/Flutter/AppFrameworkInfo.plist
+++ b/example/ios/Flutter/AppFrameworkInfo.plist
@@ -20,7 +20,5 @@
   <string>????</string>
   <key>CFBundleVersion</key>
   <string>1.0</string>
-  <key>MinimumOSVersion</key>
-  <string>13.0</string>
 </dict>
 </plist>

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -4,7 +4,7 @@ publish_to: 'none'
 version: 1.0.0+1
 
 environment:
-  sdk: '>=3.10.4 <4.0.0'
+  sdk: '>=3.11.1 <4.0.0'
 
 dependencies:
   arcgis_maps: ^300.0.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,8 +10,8 @@ topics:
 publish_to: none
 
 environment:
-  sdk: '>=3.10.4 <4.0.0'
-  flutter: '>=3.38.5'
+  sdk: '>=3.11.1 <4.0.0'
+  flutter: '>=3.41.3'
 
 dependencies:
   arcgis_maps: ^300.0.0


### PR DESCRIPTION
Update our minimum to Flutter 3.41.3 (which includes Dart 3.11.1). This version automatically updates `AppFrameworkInfo.plist` a little.