### PR TITLE
Handle BSL with no Full Model sublayer

### DIFF
--- a/lib/src/building_explorer/building_scene_layer_state.dart
+++ b/lib/src/building_explorer/building_scene_layer_state.dart
@@ -25,6 +25,8 @@ const _SOLID_BLOCK_NAME = 'solid block';
 const _XRAY_BLOCK_NAME = 'xray block';
 const _BUILDING_LEVEL_ATTRIBUTE = 'BldgLevel';
 const _CONSTRUCTION_PHASE_ATTRIBUTES = 'CreatedPhase';
+const _FULL_MODEL_SUBLAYER_MODEL_NAME = 'FullModel';
+const _OVERVIEW_SUBLAYER_MODEL_NAME = 'Overview';
 
 /// Class that records the state of a single building scene layer. The
 /// properties of this class drive UI elements for a specific building scene layer.
@@ -46,7 +48,7 @@ class _BuildingSceneLayerState {
   }) {
     // Check if the layer has an overview model
     final overviewSublayerIndex = layer.sublayers.indexWhere(
-      (layer) => layer.name == 'Overview',
+      (layer) => layer.modelName == _OVERVIEW_SUBLAYER_MODEL_NAME,
     );
 
     return _BuildingSceneLayerState._(

--- a/lib/src/building_explorer/support_widgets/building_category_list.dart
+++ b/lib/src/building_explorer/support_widgets/building_category_list.dart
@@ -34,15 +34,22 @@ class _BuildingCategoryList extends StatelessWidget {
   Widget build(BuildContext context) {
     final fullModelGroupSublayer = buildingSceneLayer.sublayers
         .whereType<BuildingGroupSublayer>()
-        .where((sublayer) => sublayer.name == 'Full Model')
+        .where(
+          (sublayer) => sublayer.modelName == _FULL_MODEL_SUBLAYER_MODEL_NAME,
+        )
         .firstOrNull;
 
+    // If there is no "Full Model" sublayerGroup, the top-level groups are the
+    // disciplines.
     final disciplineGroupSublayers =
         fullModelGroupSublayer?.sublayers
             .whereType<BuildingGroupSublayer>()
             .toList() ??
-        [];
+        buildingSceneLayer.sublayers
+            .whereType<BuildingGroupSublayer>()
+            .toList();
 
+    // Sort the list by the sublayer names.
     disciplineGroupSublayers.sort(
       (discipline1, discipline2) =>
           discipline1.name.compareTo(discipline2.name),

--- a/lib/src/building_explorer/support_widgets/overview_model_toggle.dart
+++ b/lib/src/building_explorer/support_widgets/overview_model_toggle.dart
@@ -48,14 +48,12 @@ class _OverviewModelToggleState extends State<_OverviewModelToggle> {
           onChanged: (newValue) {
             // Set the Full Model sublayer visibility
             widget.layerState.buildingSceneLayer.sublayers
-                    .firstWhere((layer) => layer.name == 'Full Model')
+                    .firstWhere(
+                      (layer) =>
+                          layer.modelName == _FULL_MODEL_SUBLAYER_MODEL_NAME,
+                    )
                     .isVisible =
                 !newValue;
-
-            // If the Overview is visible, remove the applied layer filters.
-            if (newValue) {
-              widget.layerState.buildingSceneLayer.activeFilter = null;
-            }
 
             setState(() {
               // Set the Overview sublayer visiblity.


### PR DESCRIPTION
### Description
In a Building Scene Layer that has an "Overview" sublayer, there will also be a "Full Model" sublayerGroup that contains all of the Discipline sublayerGroups. In BSLs without an "Overview", there is also no "Full Model". The disciplines are the top level. This PR modifies the Building Explorer to handle the second case.

This also removes code that removed the BuildingFilter when the Overview is shown. RTC has updated BSL so that BuildingFilter does not apply to the Overview sublayer.

### PR modifications
- Replaced "name" with "modelName" for sublayer identification
- Added const vars for "FullModel" and "Overview" modelNames
- Removed code to remove BuildingFilter when "Overview" selected. This is handled by RTC now.
- If no "FullModel" sublayerGroup, top level sublayerGroups are considered as the discipline sublayerGroups