### PR TITLE
Building Explorer UI updates

### DIFF
--- a/lib/arcgis_maps_toolkit.dart
+++ b/lib/arcgis_maps_toolkit.dart
@@ -55,6 +55,7 @@ part 'src/building_explorer/support_widgets/building_level_selector.dart';
 part 'src/building_explorer/support_widgets/building_scene_layer_selector.dart';
 part 'src/building_explorer/building_scene_layer_state.dart';
 part 'src/building_explorer/support_widgets/construction_phase_selector.dart';
+part 'src/building_explorer/support_widgets/layer_visibility_toggle.dart';
 part 'src/building_explorer/support_widgets/overview_model_toggle.dart';
 part 'src/building_explorer/support_widgets/zoom_to_building_control.dart';
 // Compass Widget

--- a/lib/src/building_explorer/building_explorer.dart
+++ b/lib/src/building_explorer/building_explorer.dart
@@ -199,8 +199,8 @@ class _BuildingExplorerState extends State<BuildingExplorer> {
   }
 
   Widget _buildFullBuildingExplorer(BuildContext context) {
-    var overviewShowing =
-        widgetController._selectedBuildingSceneLayerState!.showOverview;
+    var fullModelShowing =
+        widgetController._selectedBuildingSceneLayerState!.showFullModel;
 
     return Column(
       children: [
@@ -237,18 +237,18 @@ class _BuildingExplorerState extends State<BuildingExplorer> {
                       _ZoomToBuildingControl(
                         buildingExplorerController: widgetController,
                       ),
-                      // Overview model toggle widget.
+                      // Overview sublayer toggle widget.
                       _OverviewModelToggle(
                         layerState:
                             widgetController._selectedBuildingSceneLayerState!,
                         onOverviewVisibilityChanged: (newValue) =>
-                            setState(() => overviewShowing = newValue),
+                            setState(() => fullModelShowing = newValue),
                       ),
                     ],
                   ),
                 ),
                 // Hide the rest of the controls if the overview is showing.
-                if (!overviewShowing)
+                if (fullModelShowing)
                   Column(
                     children: [
                       // Widget for selecting the level to highlight.

--- a/lib/src/building_explorer/building_explorer.dart
+++ b/lib/src/building_explorer/building_explorer.dart
@@ -302,8 +302,8 @@ class _BuildingExplorerState extends State<BuildingExplorer> {
                           ),
                           // Disciplines and Categories listing widget.
                           _BuildingCategoryList(
-                            buildingSceneLayer:
-                                widgetController._selectedLayer!,
+                            buildingSceneLayerState: widgetController
+                                ._selectedBuildingSceneLayerState!,
                             shrinkWrap: true,
                             scrollPhysics: const NeverScrollableScrollPhysics(),
                           ),

--- a/lib/src/building_explorer/building_explorer.dart
+++ b/lib/src/building_explorer/building_explorer.dart
@@ -125,6 +125,9 @@ class _BuildingExplorerState extends State<BuildingExplorer> {
     }
   }
 
+  // Function that defines the "Loading" version of the Building Explorer widget.
+  // This is shown as the scene is loading and the building scene layer
+  // information is being collected.
   Widget _buildLoadingExplorer(BuildContext context) {
     return Column(
       children: [
@@ -162,6 +165,8 @@ class _BuildingExplorerState extends State<BuildingExplorer> {
     );
   }
 
+  // Function that defines the version of the Building Explorer widget when there
+  // are no building scene layers in the scene.
   Widget _buildEmptyBuildingExplorer(BuildContext context) {
     return Column(
       children: [
@@ -198,6 +203,8 @@ class _BuildingExplorerState extends State<BuildingExplorer> {
     );
   }
 
+  // Function that defines the full version of the Building Explorer widget. Shown
+  // when one or more building scene layers are present in the scene.
   Widget _buildFullBuildingExplorer(BuildContext context) {
     var fullModelShowing =
         widgetController._selectedBuildingSceneLayerState!.showFullModel;
@@ -211,6 +218,7 @@ class _BuildingExplorerState extends State<BuildingExplorer> {
         Stack(
           alignment: Alignment.center,
           children: [
+            // Building selection widget.
             _BuildingSceneLayerSelector(
               buildingExplorerController: widgetController,
               onBuildingSceneChanged: (layer) =>
@@ -276,6 +284,7 @@ class _BuildingExplorerState extends State<BuildingExplorer> {
                               buildingSceneLayerState: widgetController
                                   ._selectedBuildingSceneLayerState!,
                             ),
+                            // Construction Phase selection widget.
                             _ConstructionPhaseSelector(
                               buildingSceneLayerState: widgetController
                                   ._selectedBuildingSceneLayerState!,
@@ -291,6 +300,7 @@ class _BuildingExplorerState extends State<BuildingExplorer> {
                             'Disciplines & Categories:',
                             style: Theme.of(context).textTheme.bodyLarge,
                           ),
+                          // Disciplines and Categories listing widget.
                           _BuildingCategoryList(
                             buildingSceneLayer:
                                 widgetController._selectedLayer!,

--- a/lib/src/building_explorer/building_explorer.dart
+++ b/lib/src/building_explorer/building_explorer.dart
@@ -90,11 +90,13 @@ class _BuildingExplorerState extends State<BuildingExplorer> {
     _refreshFuture = widgetController._refreshBuildingSceneLayers();
 
     onRequestSceneRefreshSubscription = widgetController._onRequestSceneRefresh
-        .listen(
-          (_) => setState(() {
-            _refreshFuture = widgetController._refreshBuildingSceneLayers();
-          }),
-        );
+        .listen((_) {
+          if (mounted) {
+            setState(() {
+              _refreshFuture = widgetController._refreshBuildingSceneLayers();
+            });
+          }
+        });
   }
 
   @override

--- a/lib/src/building_explorer/building_explorer.dart
+++ b/lib/src/building_explorer/building_explorer.dart
@@ -245,12 +245,20 @@ class _BuildingExplorerState extends State<BuildingExplorer> {
                             setState(() => layerVisible = newValue),
                       ),
                       if (layerVisible)
-                        // Overview sublayer toggle widget.
-                        _OverviewModelToggle(
-                          layerState: widgetController
-                              ._selectedBuildingSceneLayerState!,
-                          onOverviewVisibilityChanged: (newValue) =>
-                              setState(() => fullModelShowing = newValue),
+                        Column(
+                          children: [
+                            // Overview sublayer toggle widget.
+                            _OverviewModelToggle(
+                              layerState: widgetController
+                                  ._selectedBuildingSceneLayerState!,
+                              onOverviewVisibilityChanged: (newValue) =>
+                                  setState(() => fullModelShowing = newValue),
+                            ),
+                            // Zoom to Building widget.
+                            _ZoomToBuildingControl(
+                              buildingExplorerController: widgetController,
+                            ),
+                          ],
                         ),
                     ],
                   ),
@@ -263,10 +271,6 @@ class _BuildingExplorerState extends State<BuildingExplorer> {
                         padding: const EdgeInsets.fromLTRB(15, 0, 20, 0),
                         child: Column(
                           children: [
-                            // Zoom to Building widget.
-                            _ZoomToBuildingControl(
-                              buildingExplorerController: widgetController,
-                            ),
                             // Widget for selecting the level to highlight.
                             _BuildingLevelSelector(
                               buildingSceneLayerState: widgetController

--- a/lib/src/building_explorer/building_explorer.dart
+++ b/lib/src/building_explorer/building_explorer.dart
@@ -201,6 +201,10 @@ class _BuildingExplorerState extends State<BuildingExplorer> {
   Widget _buildFullBuildingExplorer(BuildContext context) {
     var fullModelShowing =
         widgetController._selectedBuildingSceneLayerState!.showFullModel;
+    var layerVisible = widgetController
+        ._selectedBuildingSceneLayerState!
+        .buildingSceneLayer
+        .isVisible;
 
     return Column(
       children: [
@@ -233,43 +237,63 @@ class _BuildingExplorerState extends State<BuildingExplorer> {
                   padding: const EdgeInsets.fromLTRB(15, 0, 20, 0),
                   child: Column(
                     children: [
-                      // Zoom to Building widget.
-                      _ZoomToBuildingControl(
-                        buildingExplorerController: widgetController,
-                      ),
-                      // Overview sublayer toggle widget.
-                      _OverviewModelToggle(
+                      // Layer visibility toggle widget
+                      _LayerVisibilityToggle(
                         layerState:
                             widgetController._selectedBuildingSceneLayerState!,
-                        onOverviewVisibilityChanged: (newValue) =>
-                            setState(() => fullModelShowing = newValue),
+                        onLayerVisibilityChanged: (newValue) =>
+                            setState(() => layerVisible = newValue),
                       ),
+                      if (layerVisible)
+                        // Overview sublayer toggle widget.
+                        _OverviewModelToggle(
+                          layerState: widgetController
+                              ._selectedBuildingSceneLayerState!,
+                          onOverviewVisibilityChanged: (newValue) =>
+                              setState(() => fullModelShowing = newValue),
+                        ),
                     ],
                   ),
                 ),
                 // Hide the rest of the controls if the overview is showing.
-                if (fullModelShowing)
+                if (fullModelShowing && layerVisible)
                   Column(
                     children: [
-                      // Widget for selecting the level to highlight.
-                      _BuildingLevelSelector(
-                        buildingSceneLayerState:
-                            widgetController._selectedBuildingSceneLayerState!,
+                      Padding(
+                        padding: const EdgeInsets.fromLTRB(15, 0, 20, 0),
+                        child: Column(
+                          children: [
+                            // Zoom to Building widget.
+                            _ZoomToBuildingControl(
+                              buildingExplorerController: widgetController,
+                            ),
+                            // Widget for selecting the level to highlight.
+                            _BuildingLevelSelector(
+                              buildingSceneLayerState: widgetController
+                                  ._selectedBuildingSceneLayerState!,
+                            ),
+                            _ConstructionPhaseSelector(
+                              buildingSceneLayerState: widgetController
+                                  ._selectedBuildingSceneLayerState!,
+                            ),
+                          ],
+                        ),
                       ),
-                      _ConstructionPhaseSelector(
-                        buildingSceneLayerState:
-                            widgetController._selectedBuildingSceneLayerState!,
-                      ),
-                      const Divider(),
-                      // Categories sublayer selection widget.
-                      Text(
-                        'Disciplines & Categories:',
-                        style: Theme.of(context).textTheme.bodyLarge,
-                      ),
-                      _BuildingCategoryList(
-                        buildingSceneLayer: widgetController._selectedLayer!,
-                        shrinkWrap: true,
-                        scrollPhysics: const NeverScrollableScrollPhysics(),
+                      Column(
+                        children: [
+                          const Divider(),
+                          // Categories sublayer selection widget.
+                          Text(
+                            'Disciplines & Categories:',
+                            style: Theme.of(context).textTheme.bodyLarge,
+                          ),
+                          _BuildingCategoryList(
+                            buildingSceneLayer:
+                                widgetController._selectedLayer!,
+                            shrinkWrap: true,
+                            scrollPhysics: const NeverScrollableScrollPhysics(),
+                          ),
+                        ],
                       ),
                     ],
                   ),

--- a/lib/src/building_explorer/building_explorer_controller.dart
+++ b/lib/src/building_explorer/building_explorer_controller.dart
@@ -89,9 +89,6 @@ class BuildingExplorerController {
   Future<void> _refreshBuildingSceneLayerStates(
     List<BuildingSceneLayer> buildingSceneLayers,
   ) async {
-    // Clear out the existing state map.
-    _buildingSceneLayerStates.clear();
-
     final refreshFutures = <Future<void>>[];
 
     // Create BuildingSceneLayerStates from the layers.
@@ -107,10 +104,22 @@ class BuildingExplorerController {
       (layer1, layer2) => layer1.name.compareTo(layer2.name),
     );
 
-    // Load up the state map.
+    // Create a map of the building layer state objects based on the sorted buildingSceneLayers.
+    final tempStates =
+        <String, _BuildingSceneLayerState>{}
+            as LinkedHashMap<String, _BuildingSceneLayerState>;
     for (final layer in buildingSceneLayers) {
-      _buildingSceneLayerStates[layer.id] =
+      // If a state object already exists for this layer, use it. Otherwise,
+      // create a new one.
+      tempStates[layer.id] =
+          _buildingSceneLayerStates[layer.id] ??
           _BuildingSceneLayerState.withBuildingSceneLayer(layer);
     }
+
+    // Replace _buildingSceneLayerStates contents with tempMap. This will remove
+    // any layer states no longer in the scene, and add new ones all in the
+    // sorted order.
+    _buildingSceneLayerStates.clear();
+    _buildingSceneLayerStates.addAll(tempStates);
   }
 }

--- a/lib/src/building_explorer/building_explorer_controller.dart
+++ b/lib/src/building_explorer/building_explorer_controller.dart
@@ -29,8 +29,8 @@ class BuildingExplorerController {
   /// scene layers. This provides the scene that contains the layers.
   final ArcGISLocalSceneViewController _localSceneViewController;
 
-  /// Map of relevent state for each of the building scene layers. The id of the
-  /// [BuildingSceneLayer] is used as the key, and the value is a
+  /// Map of relevent state for each of the building scene layers.
+  /// [BuildingSceneLayer.id] is used as the key, and the value is the associated
   /// [_BuildingSceneLayerState] object.
   var _buildingSceneLayerStates = <String, _BuildingSceneLayerState>{};
 

--- a/lib/src/building_explorer/building_explorer_controller.dart
+++ b/lib/src/building_explorer/building_explorer_controller.dart
@@ -32,7 +32,9 @@ class BuildingExplorerController {
   /// Map of relevent state for each of the building scene layers.
   /// [BuildingSceneLayer.id] is used as the key, and the value is the associated
   /// [_BuildingSceneLayerState] object.
-  var _buildingSceneLayerStates = <String, _BuildingSceneLayerState>{};
+  final _buildingSceneLayerStates =
+      <String, _BuildingSceneLayerState>{}
+          as LinkedHashMap<String, _BuildingSceneLayerState>;
 
   /// The [BuildingSceneLayer] currently active in the [BuildingExplorer].
   BuildingSceneLayer? _selectedLayer;
@@ -61,7 +63,7 @@ class BuildingExplorerController {
     final scene = _localSceneViewController.arcGISScene;
     if (scene == null) {
       _selectedLayer = null;
-      _buildingSceneLayerStates = {};
+      _buildingSceneLayerStates.clear();
       return;
     }
 
@@ -74,9 +76,7 @@ class BuildingExplorerController {
     if (buildingSceneLayers.isEmpty) return;
 
     // Refresh the state records for the building scene layers.
-    _buildingSceneLayerStates = await _refreshBuildingSceneLayerStates(
-      buildingSceneLayers,
-    );
+    await _refreshBuildingSceneLayerStates(buildingSceneLayers);
 
     // Set selectedLayer.
     // If a layer has not yet been selected, or the selection is no longer in
@@ -86,27 +86,31 @@ class BuildingExplorerController {
     }
   }
 
-  Future<Map<String, _BuildingSceneLayerState>>
-  _refreshBuildingSceneLayerStates(
+  Future<void> _refreshBuildingSceneLayerStates(
     List<BuildingSceneLayer> buildingSceneLayers,
   ) async {
+    // Clear out the existing state map.
+    _buildingSceneLayerStates.clear();
+
     final refreshFutures = <Future<void>>[];
-    final refreshedLayerStates = <String, _BuildingSceneLayerState>{};
 
     // Create BuildingSceneLayerStates from the layers.
     for (final layer in buildingSceneLayers) {
-      final refreshFuture = layer.load().then((_) {
-        refreshedLayerStates[layer.id] =
-            _buildingSceneLayerStates[layer.id] ??
-            _BuildingSceneLayerState.withBuildingSceneLayer(layer);
-      });
-
-      refreshFutures.add(refreshFuture);
+      refreshFutures.add(layer.load());
     }
 
     // Wait for all the building scene layers to load.
     await Future.wait(refreshFutures);
 
-    return refreshedLayerStates;
+    // Sort the states by building scene layer name.
+    buildingSceneLayers.sort(
+      (layer1, layer2) => layer1.name.compareTo(layer2.name),
+    );
+
+    // Load up the state map.
+    for (final layer in buildingSceneLayers) {
+      _buildingSceneLayerStates[layer.id] =
+          _BuildingSceneLayerState.withBuildingSceneLayer(layer);
+    }
   }
 }

--- a/lib/src/building_explorer/building_explorer_controller.dart
+++ b/lib/src/building_explorer/building_explorer_controller.dart
@@ -29,17 +29,17 @@ class BuildingExplorerController {
   /// scene layers. This provides the scene that contains the layers.
   final ArcGISLocalSceneViewController _localSceneViewController;
 
-  /// Map of relevent state for each of the building scene layers. The [BuildingSceneLayer]
-  /// is used as the key, and the value is a [_BuildingSceneLayerState] object.
-  var _buildingSceneLayerStates =
-      <BuildingSceneLayer, _BuildingSceneLayerState>{};
+  /// Map of relevent state for each of the building scene layers. The id of the
+  /// [BuildingSceneLayer] is used as the key, and the value is a
+  /// [_BuildingSceneLayerState] object.
+  var _buildingSceneLayerStates = <String, _BuildingSceneLayerState>{};
 
   /// The [BuildingSceneLayer] currently active in the [BuildingExplorer].
   BuildingSceneLayer? _selectedLayer;
 
   /// Convenience property to get the state object for the currently selected building layer.
   _BuildingSceneLayerState? get _selectedBuildingSceneLayerState {
-    return _buildingSceneLayerStates[_selectedLayer];
+    return _buildingSceneLayerStates[_selectedLayer?.id];
   }
 
   /// Stream that notifies listeners that they need to call
@@ -86,19 +86,18 @@ class BuildingExplorerController {
     }
   }
 
-  Future<Map<BuildingSceneLayer, _BuildingSceneLayerState>>
+  Future<Map<String, _BuildingSceneLayerState>>
   _refreshBuildingSceneLayerStates(
     List<BuildingSceneLayer> buildingSceneLayers,
   ) async {
     final refreshFutures = <Future<void>>[];
-    final refreshedLayerStates =
-        <BuildingSceneLayer, _BuildingSceneLayerState>{};
+    final refreshedLayerStates = <String, _BuildingSceneLayerState>{};
 
     // Create BuildingSceneLayerStates from the layers.
     for (final layer in buildingSceneLayers) {
       final refreshFuture = layer.load().then((_) {
-        refreshedLayerStates[layer] =
-            _buildingSceneLayerStates[layer] ??
+        refreshedLayerStates[layer.id] =
+            _buildingSceneLayerStates[layer.id] ??
             _BuildingSceneLayerState.withBuildingSceneLayer(layer);
       });
 

--- a/lib/src/building_explorer/building_scene_layer_state.dart
+++ b/lib/src/building_explorer/building_scene_layer_state.dart
@@ -36,7 +36,6 @@ class _BuildingSceneLayerState {
     required this.buildingSceneLayer,
     this.selectedLevel = 'All',
     this.selectedConstructionPhase,
-    this.fullModelSublayer,
   });
 
   /// Creates and initializes a [BuildingSceneLayerState] object for the
@@ -46,18 +45,10 @@ class _BuildingSceneLayerState {
     String selectedLevel = 'All',
     String? selectedConstructionPhase,
   }) {
-    // Check if the layer has an Full Model sublayer
-    final fullModelSublayerIndex = layer.sublayers.indexWhere(
-      (layer) => layer.modelName == _FULL_MODEL_SUBLAYER_MODEL_NAME,
-    );
-
     return _BuildingSceneLayerState._(
       buildingSceneLayer: layer,
       selectedLevel: selectedLevel,
       selectedConstructionPhase: selectedConstructionPhase,
-      fullModelSublayer: fullModelSublayerIndex > -1
-          ? layer.sublayers[fullModelSublayerIndex]
-          : null,
     );
   }
 
@@ -75,7 +66,27 @@ class _BuildingSceneLayerState {
   BuildingFilter? currentBuildingFilter;
 
   /// Full Model sublayer if one exists in the building scene layer.
-  final BuildingSublayer? fullModelSublayer;
+  BuildingGroupSublayer? get fullModelSublayer {
+    // Check if the layer has an Full Model sublayer
+    final fullModelSublayerIndex = buildingSceneLayer.sublayers.indexWhere(
+      (layer) => layer.modelName == _FULL_MODEL_SUBLAYER_MODEL_NAME,
+    );
+    return fullModelSublayerIndex > -1
+        ? buildingSceneLayer.sublayers[fullModelSublayerIndex]
+              as BuildingGroupSublayer
+        : null;
+  }
+
+  /// Overview sublayer if one exists in the building scene layer.
+  BuildingSublayer? get overviewSublayer {
+    // Check if the layer has an Full Model sublayer
+    final overviewSublayerIndex = buildingSceneLayer.sublayers.indexWhere(
+      (layer) => layer.modelName == _OVERVIEW_SUBLAYER_MODEL_NAME,
+    );
+    return overviewSublayerIndex > -1
+        ? buildingSceneLayer.sublayers[overviewSublayerIndex]
+        : null;
+  }
 
   /// Flag for the state of the Show Full Model toggle control.
   bool get showFullModel => fullModelSublayer?.isVisible ?? true;

--- a/lib/src/building_explorer/building_scene_layer_state.dart
+++ b/lib/src/building_explorer/building_scene_layer_state.dart
@@ -35,7 +35,7 @@ class _BuildingSceneLayerState {
   _BuildingSceneLayerState._({
     required this.buildingSceneLayer,
     this.selectedLevel = 'All',
-    this.selectedConstructionPhase = 'All',
+    this.selectedConstructionPhase,
     this.fullModelSublayer,
   });
 
@@ -44,7 +44,7 @@ class _BuildingSceneLayerState {
   factory _BuildingSceneLayerState.withBuildingSceneLayer(
     BuildingSceneLayer layer, {
     String selectedLevel = 'All',
-    String selectedConstructionPhase = 'All',
+    String? selectedConstructionPhase,
   }) {
     // Check if the layer has an Full Model sublayer
     final fullModelSublayerIndex = layer.sublayers.indexWhere(
@@ -67,8 +67,8 @@ class _BuildingSceneLayerState {
   /// The currently selected building level. This can be 'All' or the level name.
   String selectedLevel;
 
-  /// The currently selected construction phase. This can be 'All' or the phase name.
-  String selectedConstructionPhase;
+  /// The currently selected construction phase. This can be 'null' or the phase name.
+  String? selectedConstructionPhase;
 
   /// The current [BuildingFilter] for the selected level. If the selected level
   /// is 'All' this filter will be null.
@@ -78,12 +78,12 @@ class _BuildingSceneLayerState {
   final BuildingSublayer? fullModelSublayer;
 
   /// Flag for the state of the Show Full Model toggle control.
-  bool get showFullModel => fullModelSublayer?.isVisible ?? false;
+  bool get showFullModel => fullModelSublayer?.isVisible ?? true;
 
   /// Function to build a [BuildingFilter] based on the currently selected level
   /// and construction phase.
   void updateBuildingFilter() {
-    if (selectedLevel == 'All' && selectedConstructionPhase == 'All') {
+    if (selectedLevel == 'All' && selectedConstructionPhase == null) {
       currentBuildingFilter = null;
       buildingSceneLayer.activeFilter = null;
       return;
@@ -93,7 +93,7 @@ class _BuildingSceneLayerState {
     var solidFilterWhere = '';
     var xrayFilterWhere = '';
 
-    if (selectedConstructionPhase != 'All') {
+    if (selectedConstructionPhase != null) {
       // Construction phase where clause.
       final constructionPhaseWhere =
           '$_CONSTRUCTION_PHASE_ATTRIBUTES <= $selectedConstructionPhase';

--- a/lib/src/building_explorer/building_scene_layer_state.dart
+++ b/lib/src/building_explorer/building_scene_layer_state.dart
@@ -36,7 +36,7 @@ class _BuildingSceneLayerState {
     required this.buildingSceneLayer,
     this.selectedLevel = 'All',
     this.selectedConstructionPhase = 'All',
-    this.overviewSublayer,
+    this.fullModelSublayer,
   });
 
   /// Creates and initializes a [BuildingSceneLayerState] object for the
@@ -46,17 +46,17 @@ class _BuildingSceneLayerState {
     String selectedLevel = 'All',
     String selectedConstructionPhase = 'All',
   }) {
-    // Check if the layer has an overview model
-    final overviewSublayerIndex = layer.sublayers.indexWhere(
-      (layer) => layer.modelName == _OVERVIEW_SUBLAYER_MODEL_NAME,
+    // Check if the layer has an Full Model sublayer
+    final fullModelSublayerIndex = layer.sublayers.indexWhere(
+      (layer) => layer.modelName == _FULL_MODEL_SUBLAYER_MODEL_NAME,
     );
 
     return _BuildingSceneLayerState._(
       buildingSceneLayer: layer,
       selectedLevel: selectedLevel,
       selectedConstructionPhase: selectedConstructionPhase,
-      overviewSublayer: overviewSublayerIndex > -1
-          ? layer.sublayers[overviewSublayerIndex]
+      fullModelSublayer: fullModelSublayerIndex > -1
+          ? layer.sublayers[fullModelSublayerIndex]
           : null,
     );
   }
@@ -74,11 +74,11 @@ class _BuildingSceneLayerState {
   /// is 'All' this filter will be null.
   BuildingFilter? currentBuildingFilter;
 
-  /// Flag for the state of the Show Overview toggle control.
-  bool get showOverview => overviewSublayer?.isVisible ?? false;
+  /// Full Model sublayer if one exists in the building scene layer.
+  final BuildingSublayer? fullModelSublayer;
 
-  /// Overview sublayer if one exists in the building scene layer.
-  final BuildingSublayer? overviewSublayer;
+  /// Flag for the state of the Show Full Model toggle control.
+  bool get showFullModel => fullModelSublayer?.isVisible ?? false;
 
   /// Function to build a [BuildingFilter] based on the currently selected level
   /// and construction phase.

--- a/lib/src/building_explorer/support_widgets/building_category_list.dart
+++ b/lib/src/building_explorer/support_widgets/building_category_list.dart
@@ -19,12 +19,12 @@ part of '../../../arcgis_maps_toolkit.dart';
 /// Widget that lists the Disciplines in the Full Model in the building scene layer.
 class _BuildingCategoryList extends StatelessWidget {
   const _BuildingCategoryList({
-    required this.buildingSceneLayer,
+    required this.buildingSceneLayerState,
     this.shrinkWrap = false,
     this.scrollPhysics,
   });
 
-  final BuildingSceneLayer buildingSceneLayer;
+  final _BuildingSceneLayerState buildingSceneLayerState;
 
   // shrinkWrap and scrollPhysics values will be applied to the ListView builder.
   final bool shrinkWrap;
@@ -32,12 +32,7 @@ class _BuildingCategoryList extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final fullModelGroupSublayer = buildingSceneLayer.sublayers
-        .whereType<BuildingGroupSublayer>()
-        .where(
-          (sublayer) => sublayer.modelName == _FULL_MODEL_SUBLAYER_MODEL_NAME,
-        )
-        .firstOrNull;
+    final fullModelGroupSublayer = buildingSceneLayerState.fullModelSublayer;
 
     // If there is no "Full Model" sublayerGroup, the top-level groups are the
     // disciplines.
@@ -45,7 +40,7 @@ class _BuildingCategoryList extends StatelessWidget {
         fullModelGroupSublayer?.sublayers
             .whereType<BuildingGroupSublayer>()
             .toList() ??
-        buildingSceneLayer.sublayers
+        buildingSceneLayerState.buildingSceneLayer.sublayers
             .whereType<BuildingGroupSublayer>()
             .toList();
 

--- a/lib/src/building_explorer/support_widgets/building_level_selector.dart
+++ b/lib/src/building_explorer/support_widgets/building_level_selector.dart
@@ -96,7 +96,7 @@ class _BuildingLevelSelectorState extends State<_BuildingLevelSelector> {
       });
 
       // Setting state after await. Check if the widget is mounted.
-      if (context.mounted) {
+      if (mounted) {
         setState(() {
           _levelList = levelList;
         });

--- a/lib/src/building_explorer/support_widgets/building_level_selector.dart
+++ b/lib/src/building_explorer/support_widgets/building_level_selector.dart
@@ -61,25 +61,22 @@ class _BuildingLevelSelectorState extends State<_BuildingLevelSelector> {
   @override
   Widget build(BuildContext context) {
     final options = ['All', ..._levelList];
-    return Padding(
-      padding: const EdgeInsets.fromLTRB(15, 0, 20, 0),
-      child: Row(
-        children: [
-          const Text('Level:'),
-          const Spacer(),
-          DropdownButton(
-            value: options.length == 1
-                ? 'All'
-                : widget.buildingSceneLayerState.selectedLevel,
-            items: options
-                .map(
-                  (value) => DropdownMenuItem(value: value, child: Text(value)),
-                )
-                .toList(),
-            onChanged: onLevelChanged,
-          ),
-        ],
-      ),
+    return Row(
+      children: [
+        const Text('Level:'),
+        const Spacer(),
+        DropdownButton(
+          value: options.length == 1
+              ? 'All'
+              : widget.buildingSceneLayerState.selectedLevel,
+          items: options
+              .map(
+                (value) => DropdownMenuItem(value: value, child: Text(value)),
+              )
+              .toList(),
+          onChanged: onLevelChanged,
+        ),
+      ],
     );
   }
 

--- a/lib/src/building_explorer/support_widgets/building_scene_layer_selector.dart
+++ b/lib/src/building_explorer/support_widgets/building_scene_layer_selector.dart
@@ -42,12 +42,12 @@ class _BuildingSceneLayerSelector extends StatelessWidget {
       // Dropdown to select building from scene.
       return DropdownButton(
         value: widgetController._selectedLayer,
-        items: widgetController._buildingSceneLayerStates.keys
+        items: widgetController._buildingSceneLayerStates.values
             .map(
               (e) => DropdownMenuItem(
-                value: e,
+                value: e.buildingSceneLayer,
                 child: Text(
-                  e.name,
+                  e.buildingSceneLayer.name,
                   style: Theme.of(context).textTheme.headlineSmall,
                   textAlign: TextAlign.center,
                 ),

--- a/lib/src/building_explorer/support_widgets/construction_phase_selector.dart
+++ b/lib/src/building_explorer/support_widgets/construction_phase_selector.dart
@@ -39,10 +39,6 @@ class _ConstructionPhaseSelectorState
 
     // Get the state for the new BuidlingSceneLayer
     _initPhaseList();
-
-    // Check if the selected construction phase is still valid for the current state of the
-    // building layer.
-    _checkSelectedPhase();
   }
 
   @override
@@ -50,22 +46,16 @@ class _ConstructionPhaseSelectorState
     super.didUpdateWidget(oldWidget);
 
     // Reset the state variables
-    _constructionPhaseList = <String>[];
+    _constructionPhaseList = [];
 
     // Get the state for the new BuidlingSceneLayer
     _initPhaseList();
-
-    // Check if the selected phase is still valid for the current state of the
-    // building layer.
-    _checkSelectedPhase();
   }
 
   @override
   Widget build(BuildContext context) {
-    final options = ['All', ..._constructionPhaseList];
-
-    if (options.length < 3) {
-      // Don't show the widget if there is less than two phases (excluding 'All').
+    if (_constructionPhaseList.length < 2) {
+      // Don't show the widget if there are less than two phases.
       return const SizedBox.shrink();
     }
 
@@ -75,7 +65,7 @@ class _ConstructionPhaseSelectorState
         const Spacer(),
         DropdownButton(
           value: widget.buildingSceneLayerState.selectedConstructionPhase,
-          items: options
+          items: _constructionPhaseList
               .map(
                 (value) => DropdownMenuItem(value: value, child: Text(value)),
               )
@@ -101,6 +91,10 @@ class _ConstructionPhaseSelectorState
         return intB.compareTo(intA);
       });
 
+      // Check if the selected phase is still valid for the current state of the
+      // building layer.
+      _checkSelectedPhase(phaseList);
+
       // Setting state after await. Check if the widget is mounted.
       if (context.mounted) {
         setState(() {
@@ -110,17 +104,23 @@ class _ConstructionPhaseSelectorState
     }
   }
 
-  void _checkSelectedPhase() {
-    if (!identical(
-      widget.buildingSceneLayerState.buildingSceneLayer.activeFilter,
-      widget.buildingSceneLayerState.currentBuildingFilter,
-    )) {
-      // The active filter for the layer was not set by this widget. The
-      // selected layer is invalid.
-      widget.buildingSceneLayerState.selectedConstructionPhase = 'All';
+  void _checkSelectedPhase(List<String> phaseList) {
+    if (widget.buildingSceneLayerState.selectedConstructionPhase == null &&
+        phaseList.isNotEmpty) {
+      // Due to sorting, the first element is the last of the construction phases.
+      widget.buildingSceneLayerState.selectedConstructionPhase =
+          phaseList.first;
+    } else if (widget.buildingSceneLayerState.selectedConstructionPhase !=
+            null &&
+        !phaseList.contains(
+          widget.buildingSceneLayerState.selectedConstructionPhase,
+        )) {
+      // The selected phase is no longer in the phase list, or the phase list is empty.
+      widget.buildingSceneLayerState.selectedConstructionPhase =
+          phaseList.isNotEmpty ? phaseList.first : null;
     }
 
-    // Update the building filter to the currently selected construction phase.
+    // Update the building filter to the new selected construction phase.
     widget.buildingSceneLayerState.updateBuildingFilter();
   }
 

--- a/lib/src/building_explorer/support_widgets/construction_phase_selector.dart
+++ b/lib/src/building_explorer/support_widgets/construction_phase_selector.dart
@@ -96,7 +96,7 @@ class _ConstructionPhaseSelectorState
       _checkSelectedPhase(phaseList);
 
       // Setting state after await. Check if the widget is mounted.
-      if (context.mounted) {
+      if (mounted) {
         setState(() {
           _constructionPhaseList = phaseList;
         });

--- a/lib/src/building_explorer/support_widgets/construction_phase_selector.dart
+++ b/lib/src/building_explorer/support_widgets/construction_phase_selector.dart
@@ -69,23 +69,20 @@ class _ConstructionPhaseSelectorState
       return const SizedBox.shrink();
     }
 
-    return Padding(
-      padding: const EdgeInsets.fromLTRB(15, 0, 20, 0),
-      child: Row(
-        children: [
-          const Text('Construction phase:'),
-          const Spacer(),
-          DropdownButton(
-            value: widget.buildingSceneLayerState.selectedConstructionPhase,
-            items: options
-                .map(
-                  (value) => DropdownMenuItem(value: value, child: Text(value)),
-                )
-                .toList(),
-            onChanged: onConstructionPhaseChanged,
-          ),
-        ],
-      ),
+    return Row(
+      children: [
+        const Text('Construction phase:'),
+        const Spacer(),
+        DropdownButton(
+          value: widget.buildingSceneLayerState.selectedConstructionPhase,
+          items: options
+              .map(
+                (value) => DropdownMenuItem(value: value, child: Text(value)),
+              )
+              .toList(),
+          onChanged: onConstructionPhaseChanged,
+        ),
+      ],
     );
   }
 

--- a/lib/src/building_explorer/support_widgets/construction_phase_selector.dart
+++ b/lib/src/building_explorer/support_widgets/construction_phase_selector.dart
@@ -105,22 +105,16 @@ class _ConstructionPhaseSelectorState
   }
 
   void _checkSelectedPhase(List<String> phaseList) {
-    if (widget.buildingSceneLayerState.selectedConstructionPhase == null &&
-        phaseList.isNotEmpty) {
-      // Due to sorting, the first element is the last of the construction phases.
-      widget.buildingSceneLayerState.selectedConstructionPhase =
-          phaseList.first;
-    } else if (widget.buildingSceneLayerState.selectedConstructionPhase !=
-            null &&
+    if (widget.buildingSceneLayerState.selectedConstructionPhase == null ||
         !phaseList.contains(
           widget.buildingSceneLayerState.selectedConstructionPhase,
         )) {
-      // The selected phase is no longer in the phase list, or the phase list is empty.
+      // The selected phase is null or is no longer in the phase list.
       widget.buildingSceneLayerState.selectedConstructionPhase =
-          phaseList.isNotEmpty ? phaseList.first : null;
+          phaseList.firstOrNull;
     }
 
-    // Update the building filter to the new selected construction phase.
+    // Update the building filter to the selected construction phase.
     widget.buildingSceneLayerState.updateBuildingFilter();
   }
 

--- a/lib/src/building_explorer/support_widgets/layer_visibility_toggle.dart
+++ b/lib/src/building_explorer/support_widgets/layer_visibility_toggle.dart
@@ -34,11 +34,6 @@ class _LayerVisibilityToggle extends StatefulWidget {
 class _LayerVisibilityToggleState extends State<_LayerVisibilityToggle> {
   @override
   Widget build(BuildContext context) {
-    if (widget.layerState.fullModelSublayer == null) {
-      // Show nothing if there is no overview model.
-      return const SizedBox.shrink();
-    }
-
     return Row(
       children: [
         const Text('Visible'),

--- a/lib/src/building_explorer/support_widgets/layer_visibility_toggle.dart
+++ b/lib/src/building_explorer/support_widgets/layer_visibility_toggle.dart
@@ -42,7 +42,7 @@ class _LayerVisibilityToggleState extends State<_LayerVisibilityToggle> {
           value: widget.layerState.buildingSceneLayer.isVisible,
           onChanged: (newValue) {
             setState(() {
-              // Set the layer's visiblity.
+              // Set the layer's visibility.
               widget.layerState.buildingSceneLayer.isVisible = newValue;
             });
 

--- a/lib/src/building_explorer/support_widgets/layer_visibility_toggle.dart
+++ b/lib/src/building_explorer/support_widgets/layer_visibility_toggle.dart
@@ -1,0 +1,60 @@
+//
+// Copyright 2026 Esri
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+part of '../../../arcgis_maps_toolkit.dart';
+
+/// Widget to toggle Overview/Full Model sublayer visibility.
+class _LayerVisibilityToggle extends StatefulWidget {
+  const _LayerVisibilityToggle({
+    required this.layerState,
+    this.onLayerVisibilityChanged,
+  });
+
+  /// The state info for the selected buidling scene layer.
+  final _BuildingSceneLayerState layerState;
+  final void Function(bool isLayerVisible)? onLayerVisibilityChanged;
+
+  @override
+  State<_LayerVisibilityToggle> createState() => _LayerVisibilityToggleState();
+}
+
+class _LayerVisibilityToggleState extends State<_LayerVisibilityToggle> {
+  @override
+  Widget build(BuildContext context) {
+    if (widget.layerState.fullModelSublayer == null) {
+      // Show nothing if there is no overview model.
+      return const SizedBox.shrink();
+    }
+
+    return Row(
+      children: [
+        const Text('Visible'),
+        const Spacer(),
+        Switch(
+          value: widget.layerState.buildingSceneLayer.isVisible,
+          onChanged: (newValue) {
+            setState(() {
+              // Set the layer's visiblity.
+              widget.layerState.buildingSceneLayer.isVisible = newValue;
+            });
+
+            widget.onLayerVisibilityChanged?.call(newValue);
+          },
+        ),
+      ],
+    );
+  }
+}

--- a/lib/src/building_explorer/support_widgets/overview_model_toggle.dart
+++ b/lib/src/building_explorer/support_widgets/overview_model_toggle.dart
@@ -34,8 +34,9 @@ class _OverviewModelToggle extends StatefulWidget {
 class _OverviewModelToggleState extends State<_OverviewModelToggle> {
   @override
   Widget build(BuildContext context) {
-    if (widget.layerState.fullModelSublayer == null) {
-      // Show nothing if there is no overview model.
+    if (widget.layerState.fullModelSublayer == null ||
+        widget.layerState.overviewSublayer == null) {
+      // Show nothing if there is no Full Model or Overview sublayer.
       return const SizedBox.shrink();
     }
 
@@ -47,13 +48,7 @@ class _OverviewModelToggleState extends State<_OverviewModelToggle> {
           value: widget.layerState.showFullModel,
           onChanged: (newValue) {
             // Set the Full Model sublayer visibility
-            widget.layerState.buildingSceneLayer.sublayers
-                    .firstWhere(
-                      (layer) =>
-                          layer.modelName == _OVERVIEW_SUBLAYER_MODEL_NAME,
-                    )
-                    .isVisible =
-                !newValue;
+            widget.layerState.overviewSublayer!.isVisible = !newValue;
 
             setState(() {
               // Set the Overview sublayer visiblity.

--- a/lib/src/building_explorer/support_widgets/overview_model_toggle.dart
+++ b/lib/src/building_explorer/support_widgets/overview_model_toggle.dart
@@ -34,30 +34,30 @@ class _OverviewModelToggle extends StatefulWidget {
 class _OverviewModelToggleState extends State<_OverviewModelToggle> {
   @override
   Widget build(BuildContext context) {
-    if (widget.layerState.overviewSublayer == null) {
+    if (widget.layerState.fullModelSublayer == null) {
       // Show nothing if there is no overview model.
       return const SizedBox.shrink();
     }
 
     return Row(
       children: [
-        const Text('Show Overview'),
+        const Text('Show Full Model'),
         const Spacer(),
         Switch(
-          value: widget.layerState.showOverview,
+          value: widget.layerState.showFullModel,
           onChanged: (newValue) {
             // Set the Full Model sublayer visibility
             widget.layerState.buildingSceneLayer.sublayers
                     .firstWhere(
                       (layer) =>
-                          layer.modelName == _FULL_MODEL_SUBLAYER_MODEL_NAME,
+                          layer.modelName == _OVERVIEW_SUBLAYER_MODEL_NAME,
                     )
                     .isVisible =
                 !newValue;
 
             setState(() {
               // Set the Overview sublayer visiblity.
-              widget.layerState.overviewSublayer!.isVisible = newValue;
+              widget.layerState.fullModelSublayer!.isVisible = newValue;
             });
 
             widget.onOverviewVisibilityChanged?.call(newValue);


### PR DESCRIPTION
### Description
As other SDKs have started implementing this tool, some modifications have been made to the common design. This PR updates the Flutter SDK's Building Explorer with these changes.

### PR changes
- Added full layer visibility toggle widget
- Changed "Show Overview" to "Show Full Model" (UI and logic changes)
- Removed the "All" option from the construction phase selector. "All" is the same as the last phase. (UI and logic changes)