### PR TITLE
Add AppBar to Building Explorer example

### DIFF
--- a/example/lib/example_building_explorer.dart
+++ b/example/lib/example_building_explorer.dart
@@ -73,6 +73,7 @@ class _ExampleBuildingExplorerState extends State<ExampleBuildingExplorer> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
+      appBar: AppBar(title: const Text('Building Explorer')),
       body: SafeArea(
         top: false,
         left: false,


### PR DESCRIPTION
The Building Explorer example page did not have an AppBar. This prevented the user from returning back to the main menu. This PR adds the AppBar to the example page.