### PR TITLE
Ignore non-integer construction phase lists

### DIFF
--- a/lib/src/building_explorer/support_widgets/construction_phase_selector.dart
+++ b/lib/src/building_explorer/support_widgets/construction_phase_selector.dart
@@ -18,7 +18,9 @@ part of '../../../arcgis_maps_toolkit.dart';
 
 /// Widget to list and select building's construction phases. Selecting a phase
 /// will apply a filter to the building layer hiding all features that were not
-/// present during that construction phase.
+/// present during that construction phase. The widget expects the construction
+/// phases can be parsed to integer values and will not appear if there are any
+/// non-integer phase values.
 class _ConstructionPhaseSelector extends StatefulWidget {
   const _ConstructionPhaseSelector({required this.buildingSceneLayerState});
 
@@ -85,6 +87,16 @@ class _ConstructionPhaseSelectorState
       phaseList.addAll(
         statistics[_CONSTRUCTION_PHASE_ATTRIBUTES]!.mostFrequentValues,
       );
+
+      // Check that the construction phases are integers
+      for (final phase in phaseList) {
+        if (int.tryParse(phase) == null) {
+          // Found a text construction phase. Clear the list and end the loop.
+          phaseList.clear();
+          break;
+        }
+      }
+
       phaseList.sort((a, b) {
         final intA = int.tryParse(a) ?? 0;
         final intB = int.tryParse(b) ?? 0;

--- a/lib/src/building_explorer/support_widgets/construction_phase_selector.dart
+++ b/lib/src/building_explorer/support_widgets/construction_phase_selector.dart
@@ -88,13 +88,9 @@ class _ConstructionPhaseSelectorState
         statistics[_CONSTRUCTION_PHASE_ATTRIBUTES]!.mostFrequentValues,
       );
 
-      // Check that the construction phases are integers
-      for (final phase in phaseList) {
-        if (int.tryParse(phase) == null) {
-          // Found a text construction phase. Clear the list and end the loop.
-          phaseList.clear();
-          break;
-        }
+      if (!phaseList.every((phase) => int.tryParse(phase) != null)) {
+        // Found a non-integer construction phase. Clear the list and end the loop.
+        phaseList.clear();
       }
 
       phaseList.sort((a, b) {


### PR DESCRIPTION
The Building Explorer expects construction phases to be integers. Any text phase names will not filter properly and cannot be properly sorted by the widget. If any phases are text, the construction phase widget will not be shown, and phase will not influence the filter.

- Clear out the phase list if any text phases are encountered
- Updated widget comment