### PR TITLE
Find all building scene layers in a Scene

### DIFF
--- a/lib/src/building_explorer/building_explorer_controller.dart
+++ b/lib/src/building_explorer/building_explorer_controller.dart
@@ -128,7 +128,7 @@ class BuildingExplorerController {
   }
 
   // Recursive function to find the BuildingSceneLayers in the scene.
-  List<BuildingSceneLayer> _extractBuildingSceneLayers(List<Layer> layers) {
+  List<BuildingSceneLayer> _extractBuildingSceneLayers(Iterable<Layer> layers) {
     final buildingSceneLayers = <BuildingSceneLayer>[];
     for (final layer in layers) {
       if (layer is BuildingSceneLayer) {
@@ -136,7 +136,7 @@ class BuildingExplorerController {
       } else if (layer is GroupLayer) {
         buildingSceneLayers.addAll(
           _extractBuildingSceneLayers(
-            layer.subLayerContents.whereType<Layer>().toList(),
+            layer.subLayerContents.whereType<Layer>(),
           ),
         );
       }

--- a/lib/src/building_explorer/building_explorer_controller.dart
+++ b/lib/src/building_explorer/building_explorer_controller.dart
@@ -131,7 +131,9 @@ class BuildingExplorerController {
         buildingSceneLayers.add(layer);
       } else if (layer is GroupLayer) {
         buildingSceneLayers.addAll(
-          _extractBuildingSceneLayers(layer.subLayerContents as List<Layer>),
+          _extractBuildingSceneLayers(
+            layer.subLayerContents.whereType<Layer>().toList(),
+          ),
         );
       }
     }

--- a/lib/src/building_explorer/building_explorer_controller.dart
+++ b/lib/src/building_explorer/building_explorer_controller.dart
@@ -72,8 +72,12 @@ class BuildingExplorerController {
       scene.operationalLayers,
     );
 
-    // If none, return.
-    if (buildingSceneLayers.isEmpty) return;
+    // If none, clear _selectedLayer and _buildingSceneLayerStates then return.
+    if (buildingSceneLayers.isEmpty) {
+      _selectedLayer = null;
+      _buildingSceneLayerStates.clear();
+      return;
+    }
 
     // Refresh the state records for the building scene layers.
     await _refreshBuildingSceneLayerStates(buildingSceneLayers);

--- a/lib/src/building_explorer/building_explorer_controller.dart
+++ b/lib/src/building_explorer/building_explorer_controller.dart
@@ -68,9 +68,9 @@ class BuildingExplorerController {
     }
 
     // Get the BuildingSceneLayers in the scene.
-    final buildingSceneLayers = scene.operationalLayers
-        .whereType<BuildingSceneLayer>()
-        .toList();
+    final buildingSceneLayers = _extractBuildingSceneLayers(
+      scene.operationalLayers,
+    );
 
     // If none, return.
     if (buildingSceneLayers.isEmpty) return;
@@ -121,5 +121,21 @@ class BuildingExplorerController {
     // sorted order.
     _buildingSceneLayerStates.clear();
     _buildingSceneLayerStates.addAll(tempStates);
+  }
+
+  // Recursive function to find the BuildingSceneLayers in the scene.
+  List<BuildingSceneLayer> _extractBuildingSceneLayers(List<Layer> layers) {
+    final buildingSceneLayers = <BuildingSceneLayer>[];
+    for (final layer in layers) {
+      if (layer is BuildingSceneLayer) {
+        buildingSceneLayers.add(layer);
+      } else if (layer is GroupLayer) {
+        buildingSceneLayers.addAll(
+          _extractBuildingSceneLayers(layer.subLayerContents as List<Layer>),
+        );
+      }
+    }
+
+    return buildingSceneLayers;
   }
 }


### PR DESCRIPTION
### Description
Building scene layers can be at the top level and in group layers of the `operationalLayers` property of the scene. The Building Explorer has been updated to now search recursively through all layers and group layers in the scene to find all of the building scene layers

### PR details
- Added recursive function to find all BuildingSceneLayers in the Scene