### PR TITLE
Building Explorer BSL search logic fix

### DIFF
--- a/lib/src/building_explorer/building_explorer_controller.dart
+++ b/lib/src/building_explorer/building_explorer_controller.dart
@@ -134,11 +134,7 @@ class BuildingExplorerController {
       if (layer is BuildingSceneLayer) {
         buildingSceneLayers.add(layer);
       } else if (layer is GroupLayer) {
-        buildingSceneLayers.addAll(
-          _extractBuildingSceneLayers(
-            layer.subLayerContents.whereType<Layer>(),
-          ),
-        );
+        buildingSceneLayers.addAll(_extractBuildingSceneLayers(layer.layers));
       }
     }
 


### PR DESCRIPTION
Changed algorithm in `_extractBuildingSceneLayers` to use the `layer` property instead of `subLayerContents`.