### PR TITLE
ignore overrides

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@ migrate_working_dir/
 # Flutter/Dart/Pub related
 # Libraries should not include pubspec.lock, per https://dart.dev/guides/libraries/private-files#pubspeclock.
 /pubspec.lock
+pubspec_overrides.yaml
 **/doc/api/
 .dart_tool/
 .flutter-plugins


### PR DESCRIPTION
Add `pubspec_overrides.yaml` to `.gitignore` so that we can make local overrides without them getting picked up by git.