### PR TITLE
Turn on some analyzer rules and fix the warnings

### DIFF
--- a/example/lib/example_building_explorer.dart
+++ b/example/lib/example_building_explorer.dart
@@ -65,7 +65,7 @@ class _ExampleBuildingExplorerState extends State<ExampleBuildingExplorer> {
           .map((credential) => credential.revokeToken()),
     ).then((_) {
       ArcGISEnvironment.authenticationManager.arcGISCredentialStore.removeAll();
-    });
+    }).ignore();
 
     super.dispose();
   }

--- a/example/lib/example_compass.dart
+++ b/example/lib/example_compass.dart
@@ -81,7 +81,7 @@ enum CompassExample {
           Navigator.push(
             context,
             MaterialPageRoute(builder: (_) => constructor()),
-          );
+          ).ignore();
         },
       ),
     );

--- a/example/lib/example_overview_map.dart
+++ b/example/lib/example_overview_map.dart
@@ -75,7 +75,7 @@ enum OverviewMapExample {
           Navigator.push(
             context,
             MaterialPageRoute(builder: (_) => constructor()),
-          );
+          ).ignore();
         },
       ),
     );

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -87,7 +87,7 @@ enum ComponentExample {
           Navigator.push(
             context,
             MaterialPageRoute(builder: (_) => constructor()),
-          );
+          ).ignore();
         },
       ),
     );

--- a/lib/src/authenticator/authenticator.dart
+++ b/lib/src/authenticator/authenticator.dart
@@ -202,7 +202,7 @@ class _AuthenticatorState extends State<Authenticator>
             .firstOrNull;
 
         if (configuration != null) {
-          _iapLogin(challenge, configuration);
+          _iapLogin(challenge, configuration).ignore();
         } else {
           challenge.continueAndFail();
         }
@@ -217,7 +217,7 @@ class _AuthenticatorState extends State<Authenticator>
             .firstOrNull;
 
         if (configuration != null) {
-          _oauthLogin(challenge, configuration);
+          _oauthLogin(challenge, configuration).ignore();
         } else {
           _tokenLogin(challenge);
         }
@@ -281,7 +281,7 @@ class _AuthenticatorState extends State<Authenticator>
       context: context,
       builder: (context) =>
           _AuthenticatorLogin(challenge: _ArcGISLoginChallenge(challenge)),
-    );
+    ).ignore();
   }
 
   @override

--- a/lib/src/authenticator/authenticator_login.dart
+++ b/lib/src/authenticator/authenticator_login.dart
@@ -62,9 +62,9 @@ class _NetworkLoginChallenge extends _LoginChallenge {
   @override
   String? get realm {
     switch (challenge) {
-      case BasicAuthenticationChallenge(realm: final realm):
+      case BasicAuthenticationChallenge(:final realm):
         return realm;
-      case DigestAuthenticationChallenge(realm: final realm):
+      case DigestAuthenticationChallenge(:final realm):
         return realm;
       default:
         return null;
@@ -206,9 +206,9 @@ class _AuthenticatorLoginState extends State<_AuthenticatorLogin> {
 
     // Attempt to log in with the provided username and password, using the appropriate type.
     switch (widget.challenge) {
-      case _ArcGISLoginChallenge(challenge: final challenge):
+      case _ArcGISLoginChallenge(:final challenge):
         await _loginArcGIS(challenge, username, password);
-      case _NetworkLoginChallenge(challenge: final challenge):
+      case _NetworkLoginChallenge(:final challenge):
         await _loginNetwork(challenge, username, password);
     }
   }

--- a/lib/src/building_explorer/building_explorer.dart
+++ b/lib/src/building_explorer/building_explorer.dart
@@ -101,7 +101,7 @@ class _BuildingExplorerState extends State<BuildingExplorer> {
 
   @override
   void dispose() {
-    onRequestSceneRefreshSubscription?.cancel();
+    onRequestSceneRefreshSubscription?.cancel().ignore();
     super.dispose();
   }
 

--- a/lib/src/building_explorer/support_widgets/building_level_selector.dart
+++ b/lib/src/building_explorer/support_widgets/building_level_selector.dart
@@ -36,7 +36,7 @@ class _BuildingLevelSelectorState extends State<_BuildingLevelSelector> {
     super.initState();
 
     // Get the state for the new BuidlingSceneLayer
-    _initLevelList();
+    _initLevelList().ignore();
 
     // Check if the selected level is still valid for the current state of the
     // building layer.
@@ -51,7 +51,7 @@ class _BuildingLevelSelectorState extends State<_BuildingLevelSelector> {
     _levelList = <String>[];
 
     // Get the state for the new BuidlingSceneLayer
-    _initLevelList();
+    _initLevelList().ignore();
 
     // Check if the selected level is still valid for the current state of the
     // building layer.

--- a/lib/src/building_explorer/support_widgets/construction_phase_selector.dart
+++ b/lib/src/building_explorer/support_widgets/construction_phase_selector.dart
@@ -40,7 +40,7 @@ class _ConstructionPhaseSelectorState
     super.initState();
 
     // Get the state for the new BuidlingSceneLayer
-    _initPhaseList();
+    _initPhaseList().ignore();
   }
 
   @override
@@ -51,7 +51,7 @@ class _ConstructionPhaseSelectorState
     _constructionPhaseList = [];
 
     // Get the state for the new BuidlingSceneLayer
-    _initPhaseList();
+    _initPhaseList().ignore();
   }
 
   @override

--- a/lib/src/compass/compass.dart
+++ b/lib/src/compass/compass.dart
@@ -136,9 +136,9 @@ class _CompassState extends State<Compass> {
 
   @override
   void dispose() {
-    _rotationSubscription?.cancel();
+    _rotationSubscription?.cancel().ignore();
     _rotationSubscription = null;
-    _viewpointSubscription?.cancel();
+    _viewpointSubscription?.cancel().ignore();
     _viewpointSubscription = null;
 
     super.dispose();

--- a/lib/src/overview_map/overview_map.dart
+++ b/lib/src/overview_map/overview_map.dart
@@ -170,7 +170,7 @@ class _OverviewMapState extends State<OverviewMap> {
 
   @override
   void dispose() {
-    _viewpointChangedSubscription?.cancel();
+    _viewpointChangedSubscription?.cancel().ignore();
 
     super.dispose();
   }

--- a/lib/src/popups/attachments_popup_element_view.dart
+++ b/lib/src/popups/attachments_popup_element_view.dart
@@ -188,7 +188,7 @@ class _PopupAttachmentViewInGalleryState
     // recreated every time the widget is rebuilt.
     thumbnailFuture = getThumbnailFuture(thumbnailSize.toInt());
     // Load the file path from the cache.
-    initFilePath();
+    initFilePath().ignore();
   }
 
   /// Load the thumbnail file path from the cache.
@@ -297,7 +297,7 @@ class _PopupAttachmentViewInListState
     // recreated every time the widget is rebuilt.
     thumbnailFuture = getThumbnailFuture(thumbnailSize.toInt());
     // Load the file path from the cache.
-    initFilePath();
+    initFilePath().ignore();
   }
 
   /// Load the thumbnail file path from the cache.
@@ -381,9 +381,12 @@ class _PopupAttachmentViewInListState
               context: context,
               builder: (context) =>
                   _DetailsScreenImageDialog(filePath: filePath!),
-            );
+            ).ignore();
           } else {
-            OpenFile.open(filePath, type: widget.popupAttachment.contentType);
+            OpenFile.open(
+              filePath,
+              type: widget.popupAttachment.contentType,
+            ).ignore();
           }
         }
       },

--- a/lib/src/popups/popup_views/bar_chart.dart
+++ b/lib/src/popups/popup_views/bar_chart.dart
@@ -38,18 +38,20 @@ class _PopupBarChart extends StatelessWidget {
   Widget build(BuildContext context) {
     return GestureDetector(
       onTap: () {
-        Navigator.of(context).push(
-          MaterialPageRoute<void>(
-            builder: (context) => _BarChartDetailView(
-              popupMedia: popupMedia,
-              // Bar Chart should be interactive in detail view.
-              barData: barData(interactive: true),
-              onClose: () {
-                Navigator.of(context).pop();
-              },
-            ),
-          ),
-        );
+        Navigator.of(context)
+            .push(
+              MaterialPageRoute<void>(
+                builder: (context) => _BarChartDetailView(
+                  popupMedia: popupMedia,
+                  // Bar Chart should be interactive in detail view.
+                  barData: barData(interactive: true),
+                  onClose: () {
+                    Navigator.of(context).pop();
+                  },
+                ),
+              ),
+            )
+            .ignore();
       },
       child: Stack(
         children: [

--- a/lib/src/popups/popup_views/image_media_view.dart
+++ b/lib/src/popups/popup_views/image_media_view.dart
@@ -40,16 +40,18 @@ class _ImageMediaViewState extends State<_ImageMediaView> {
       return GestureDetector(
         onTap: () {
           if (isShowingDetailReady) {
-            Navigator.of(context).push(
-              MaterialPageRoute<void>(
-                builder: (context) => _MediaDetailView(
-                  popupMedia: widget.popupMedia,
-                  onClose: () {
-                    Navigator.of(context).pop();
-                  },
-                ),
-              ),
-            );
+            Navigator.of(context)
+                .push(
+                  MaterialPageRoute<void>(
+                    builder: (context) => _MediaDetailView(
+                      popupMedia: widget.popupMedia,
+                      onClose: () {
+                        Navigator.of(context).pop();
+                      },
+                    ),
+                  ),
+                )
+                .ignore();
           }
         },
         child: Stack(
@@ -229,7 +231,7 @@ class _MediaDetailView extends StatelessWidget {
                           child: _IndicatorDot(
                             size: 16,
                             duration: Duration(
-                              milliseconds: (imageRefreshInterval / 2).toInt(),
+                              milliseconds: imageRefreshInterval ~/ 2,
                             ),
                           ),
                         ),
@@ -279,7 +281,7 @@ class _IndicatorDotState extends State<_IndicatorDot>
   void initState() {
     super.initState();
     _controller = AnimationController(vsync: this, duration: widget.duration)
-      ..repeat(reverse: true);
+      ..repeat(reverse: true).ignore();
   }
 
   @override

--- a/lib/src/popups/popup_views/line_chart.dart
+++ b/lib/src/popups/popup_views/line_chart.dart
@@ -35,18 +35,20 @@ class _PopupLineChart extends StatelessWidget {
   Widget build(BuildContext context) {
     return GestureDetector(
       onTap: () {
-        Navigator.of(context).push(
-          MaterialPageRoute<void>(
-            builder: (context) => _LineChartDetailView(
-              popupMedia: popupMedia,
-              // Line Chart should be interactive in detail view.
-              lineData: lineData(interactive: true),
-              onClose: () {
-                Navigator.of(context).pop();
-              },
-            ),
-          ),
-        );
+        Navigator.of(context)
+            .push(
+              MaterialPageRoute<void>(
+                builder: (context) => _LineChartDetailView(
+                  popupMedia: popupMedia,
+                  // Line Chart should be interactive in detail view.
+                  lineData: lineData(interactive: true),
+                  onClose: () {
+                    Navigator.of(context).pop();
+                  },
+                ),
+              ),
+            )
+            .ignore();
       },
       child: Stack(
         children: [

--- a/lib/src/popups/popup_views/pie_chart.dart
+++ b/lib/src/popups/popup_views/pie_chart.dart
@@ -38,19 +38,21 @@ class _PopupPieChart extends StatelessWidget {
         : MediaQuery.sizeOf(context).height / 3;
     return GestureDetector(
       onTap: () {
-        Navigator.of(context).push(
-          MaterialPageRoute<void>(
-            builder: (context) => _PieChartDetailView(
-              popupMedia: popupMedia,
-              chartData: chartData,
-              // Pie Charts have default size of 40. Define radius that fits within screen depending on orientation.
-              pieData: pieData(radius: radius),
-              onClose: () {
-                Navigator.of(context).pop();
-              },
-            ),
-          ),
-        );
+        Navigator.of(context)
+            .push(
+              MaterialPageRoute<void>(
+                builder: (context) => _PieChartDetailView(
+                  popupMedia: popupMedia,
+                  chartData: chartData,
+                  // Pie Charts have default size of 40. Define radius that fits within screen depending on orientation.
+                  pieData: pieData(radius: radius),
+                  onClose: () {
+                    Navigator.of(context).pop();
+                  },
+                ),
+              ),
+            )
+            .ignore();
       },
       child: Stack(
         children: [

--- a/lib/src/popups/text_popup_element_view.dart
+++ b/lib/src/popups/text_popup_element_view.dart
@@ -38,29 +38,32 @@ class _TextPopupElementViewState extends State<_TextPopupElementView> {
 
   @override
   void initState() {
-    _controller = WebViewController()
-      ..setJavaScriptMode(JavaScriptMode.unrestricted)
-      ..setNavigationDelegate(
-        NavigationDelegate(
-          onNavigationRequest: (request) {
-            final url = request.url;
-            if (url.startsWith('http') || url.startsWith('https')) {
-              _launchUri(context, url);
-              return NavigationDecision.prevent;
-            }
-            return NavigationDecision.navigate; // Allow WebView to load the URL
-          },
+    _controller = WebViewController();
+    _controller.setJavaScriptMode(JavaScriptMode.unrestricted).ignore();
+    _controller
+        .setNavigationDelegate(
+          NavigationDelegate(
+            onNavigationRequest: (request) {
+              final url = request.url;
+              if (url.startsWith('http') || url.startsWith('https')) {
+                _launchUri(context, url).ignore();
+                return NavigationDecision.prevent;
+              }
+              return NavigationDecision
+                  .navigate; // Allow WebView to load the URL
+            },
 
-          onPageFinished: (url) async {
-            final calculatedHeight = await _calculateHeight();
-            if (calculatedHeight != null) {
-              setState(() => height = calculatedHeight);
-            }
-          },
-        ),
-      )
-      ..setBackgroundColor(Colors.transparent)
-      ..loadHtmlString(_buildHTML(widget.textElement.text));
+            onPageFinished: (url) async {
+              final calculatedHeight = await _calculateHeight();
+              if (calculatedHeight != null) {
+                setState(() => height = calculatedHeight);
+              }
+            },
+          ),
+        )
+        .ignore();
+    _controller.setBackgroundColor(Colors.transparent).ignore();
+    _controller.loadHtmlString(_buildHTML(widget.textElement.text)).ignore();
 
     super.initState();
   }

--- a/linter_rules.yaml
+++ b/linter_rules.yaml
@@ -35,6 +35,7 @@ linter:
     avoid_slow_async_io: true
     avoid_type_to_string: true
     avoid_types_as_parameter_names: true
+    avoid_types_on_closure_parameters: true
     avoid_unnecessary_containers: true
     avoid_unused_constructor_parameters: true
     avoid_void_async: true
@@ -55,7 +56,9 @@ linter:
     dangling_library_doc_comments: true
     depend_on_referenced_packages: true
     deprecated_consistency: true
+    deprecated_member_use_from_same_package: true
     directives_ordering: true
+    discarded_futures: true
     document_ignores: true
     empty_catches: true
     empty_constructor_bodies: true
@@ -77,6 +80,7 @@ linter:
     library_private_types_in_public_api: true
     lines_longer_than_80_chars: false # we rely on `dart format`, which doesn't adjust comments and long strings (which is fine)
     literal_only_boolean_expressions: true
+    matching_super_parameters: true
     missing_code_block_language_in_doc_comment: true
     missing_whitespace_between_adjacent_strings: true
     no_adjacent_strings_in_list: true
@@ -84,6 +88,7 @@ linter:
     no_duplicate_case_values: true
     no_leading_underscores_for_library_prefixes: true
     no_leading_underscores_for_local_identifiers: true
+    no_literal_bool_comparisons: true
     no_logic_in_create_state: true
     no_runtimeType_toString: true
     no_self_assignments: true
@@ -112,6 +117,7 @@ linter:
     prefer_final_fields: true
     prefer_final_in_for_each: true
     prefer_final_locals: true
+    prefer_foreach: true
     prefer_for_elements_to_map_fromIterable: true
     prefer_function_declarations_over_variables: true
     prefer_generic_function_type_aliases: true
@@ -125,6 +131,7 @@ linter:
     prefer_is_not_empty: true
     prefer_is_not_operator: true
     prefer_iterable_whereType: true
+    prefer_mixin: true
     prefer_null_aware_method_calls: true
     prefer_null_aware_operators: true
     prefer_single_quotes: true
@@ -133,8 +140,10 @@ linter:
     provide_deprecation_message: true
     public_member_api_docs: false # documenting all public members would be low-value clutter
     recursive_getters: true
+    remove_deprecations_in_breaking_versions: true
     require_trailing_commas: false # this lint is incompatible with the dart formatter in Dart 3.7+
     secure_pubspec_urls: true
+    simplify_variable_pattern: true
     sized_box_for_whitespace: true
     sized_box_shrink_expand: true
     slash_for_doc_comments: true
@@ -142,7 +151,9 @@ linter:
     sort_constructors_first: true
     sort_pub_dependencies: true
     sort_unnamed_constructors_first: true
+    specify_nonobvious_property_types: false # because the definition of "non-obvious" is too broad
     strict_top_level_inference: true
+    switch_on_type: true
     test_types_in_equals: true
     throw_in_finally: true
     tighten_type_of_initializing_formals: true
@@ -164,11 +175,11 @@ linter:
     unnecessary_library_name: true
     unnecessary_new: true
     unnecessary_null_aware_assignments: true
+    unnecessary_null_aware_operator_on_extension_on_nullable: true
     unnecessary_null_checks: true
     unnecessary_null_in_if_null_operators: true
     unnecessary_nullable_for_final_variable_declarations: true
     unnecessary_overrides: true
-    unnecessary_underscores: true
     unnecessary_parenthesis: true
     unnecessary_raw_strings: true
     unnecessary_statements: true
@@ -176,6 +187,9 @@ linter:
     unnecessary_string_interpolations: true
     unnecessary_this: true
     unnecessary_to_list_in_spreads: true
+    unnecessary_underscores: true
+    unreachable_from_main: true
+    unnecessary_unawaited: true
     unrelated_type_equality_checks: true
     use_build_context_synchronously: true
     use_colored_box: true
@@ -196,5 +210,6 @@ linter:
     use_super_parameters: true
     use_test_throws_matchers: true
     use_to_and_as_if_applicable: true
+    use_truncating_division: true
     valid_regexps: true
     void_checks: true


### PR DESCRIPTION
Turn on our standard analyzer rules and fix the warnings. Mostly just "ignore()" on Futures and a simplification on case/switch pattern matching.