### PR TITLE
Updated to current version of file_picker package

### DIFF
--- a/lib/src/authenticator/authenticator.dart
+++ b/lib/src/authenticator/authenticator.dart
@@ -325,7 +325,7 @@ class _AuthenticatorState extends State<Authenticator>
     }
 
     // Browse for a pfx file.
-    final filePickerResult = await FilePicker.platform.pickFiles(
+    final filePickerResult = await FilePicker.pickFiles(
       type: FileType.custom,
       allowedExtensions: ['pfx'],
     );

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,7 +15,7 @@ environment:
 
 dependencies:
   arcgis_maps: ^300.1.0
-  file_picker: ^10.3.10
+  file_picker: ^11.0.0
   fl_chart: ^1.1.0
   flutter:
     sdk: flutter
@@ -32,5 +32,5 @@ dev_dependencies:
     sdk: flutter
 
 flutter:
- assets:
-  - assets/icons/
+  assets:
+    - assets/icons/


### PR DESCRIPTION
The `file_picker` dependency has been updated to the 11.x version. This should boost the Toolkit's pub.dev score.