### PR TITLE
[BasemapGallery] Convert HTML tooltip descriptions to plain text

### DIFF
--- a/lib/arcgis_maps_toolkit.dart
+++ b/lib/arcgis_maps_toolkit.dart
@@ -34,6 +34,7 @@ import 'package:arcgis_maps/arcgis_maps.dart';
 import 'package:file_picker/file_picker.dart';
 import 'package:fl_chart/fl_chart.dart';
 import 'package:flutter/material.dart';
+import 'package:html/parser.dart' as html_parser;
 import 'package:open_file/open_file.dart';
 import 'package:path_provider/path_provider.dart';
 import 'package:shared_preferences/shared_preferences.dart';

--- a/lib/src/basemap_gallery/basemap_gallery.dart
+++ b/lib/src/basemap_gallery/basemap_gallery.dart
@@ -290,6 +290,9 @@ final class _BasemapGalleryState extends State<BasemapGallery> {
 
 /// Tile for a basemap item; shows thumbnail, name, selection outline, and load/error state.
 final class _BasemapTile extends StatelessWidget {
+  // Keep tooltips short so long descriptions stay easy to scan.
+  static const int _maxTooltipCharacters = 400;
+
   /// Creates a tile for the basemap gallery item. Tap is disabled while loading.
   const _BasemapTile({
     required this.item,
@@ -317,6 +320,7 @@ final class _BasemapTile extends StatelessWidget {
       animation: item._tileListenable,
       builder: (context, _) {
         final isEnabled = !item._isBasemapLoading;
+        final tooltipMessage = _buildTooltipMessage();
 
         final tile = InkWell(
           borderRadius: BorderRadius.circular(6),
@@ -332,13 +336,25 @@ final class _BasemapTile extends StatelessWidget {
           enabled: isEnabled,
           label: item.name,
           child: Tooltip(
-            message: item.tooltip ?? item.name,
-            waitDuration: const Duration(milliseconds: 500),
+            message: tooltipMessage,
             child: tile,
           ),
         );
       },
     );
+  }
+
+  // Build a tooltip string and cap its length for readability.
+  String _buildTooltipMessage() {
+    // Show the item tooltip when available; otherwise show the basemap name.
+    final raw = (item.tooltip?.isNotEmpty ?? false)
+        ? item.tooltip!
+        : item.name;
+    if (raw.length <= _maxTooltipCharacters) {
+      return raw;
+    }
+    // Keep the beginning of the text and add an ellipsis when truncated.
+    return '${raw.substring(0, _maxTooltipCharacters)}...';
   }
 
   Widget _buildGridContent(BuildContext context) {

--- a/lib/src/basemap_gallery/basemap_gallery.dart
+++ b/lib/src/basemap_gallery/basemap_gallery.dart
@@ -337,6 +337,7 @@ final class _BasemapTile extends StatelessWidget {
           label: item.name,
           child: Tooltip(
             message: tooltipMessage,
+            waitDuration: const Duration(milliseconds: 500),
             child: tile,
           ),
         );

--- a/lib/src/basemap_gallery/basemap_gallery_item.dart
+++ b/lib/src/basemap_gallery/basemap_gallery_item.dart
@@ -174,9 +174,11 @@ final class BasemapGalleryItem {
   void _recomputeDerivedFields() {
     final item = _basemap.item;
 
-    final overrideTooltip = _tooltipOverride;
-    final tooltipFromItem = item?.description;
+    final overrideTooltip = _normalizeTooltipToParagraph(_tooltipOverride);
+    final tooltipFromItem = _normalizeTooltipToParagraph(item?.description);
 
+    // Use the app-provided tooltip first; otherwise fall back to the portal
+    // description when available.
     _tooltipNotifier.value = _isValidTooltip(overrideTooltip)
         ? overrideTooltip
         : (_isValidTooltip(tooltipFromItem) ? tooltipFromItem : null);
@@ -187,6 +189,8 @@ final class BasemapGalleryItem {
     final itemTitle = item?.title;
     final itemName = item?.name;
 
+    // Prefer the basemap name shown in the app, then fall back to portal
+    // metadata if needed.
     _nameNotifier.value = basemapName.isNotEmpty
         ? basemapName
         : (itemTitle != null && itemTitle.isNotEmpty)
@@ -198,6 +202,22 @@ final class BasemapGalleryItem {
 
   bool _isValidTooltip(String? tooltip) =>
       tooltip != null && tooltip.isNotEmpty;
+
+  // Converts optional HTML tooltip content into a plain-text paragraph.
+  String? _normalizeTooltipToParagraph(String? rawTooltip) {
+    if (rawTooltip == null || rawTooltip.isEmpty) {
+      return null;
+    }
+
+    final fragment = html_parser.parseFragment(rawTooltip);
+    final normalized = _collapseWhitespace(fragment.text ?? '');
+    return normalized.isEmpty ? null : normalized;
+  }
+
+  // Collapses repeated whitespace into single spaces for tooltip-friendly text.
+  String _collapseWhitespace(String input) {
+    return input.replaceAll(RegExp(r'\s+'), ' ').trim();
+  }
 
   void dispose() {
     _nameNotifier.dispose();

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -19,6 +19,7 @@ dependencies:
   fl_chart: ^1.1.0
   flutter:
     sdk: flutter
+  html: ^0.15.6
   open_file: ^3.5.10
   path_provider: ^2.1.5
   shared_preferences: ^2.5.3


### PR DESCRIPTION
This PR fixes Basemap Gallery tooltip content when portal item descriptions contain HTML markup.

`BasemapGalleryItem.tooltip` can fall back to `Item.description`. In some cases, that description includes HTML (for example `<p>`, `<a>`), which was surfacing as raw text in Flutter tooltips.

This change normalizes tooltip fallback content to plain text before rendering.