### PR TITLE
display altText if the image can't be loaded

### DIFF
--- a/lib/src/popups/popup_views/image_media_view.dart
+++ b/lib/src/popups/popup_views/image_media_view.dart
@@ -81,10 +81,25 @@ class _ImageMediaViewState extends State<_ImageMediaView> {
                   // If an image isn't available, we don't display the detail view.
                   isShowingDetailReady = false;
                   return Center(
-                    child: Icon(
-                      Icons.error_outline,
-                      color: Theme.of(context).colorScheme.error,
-                      size: 30,
+                    child: Column(
+                      mainAxisAlignment: MainAxisAlignment.center,
+                      children: [
+                        Icon(
+                          Icons.error_outline,
+                          color: Theme.of(context).colorScheme.error,
+                          size: 30,
+                        ),
+                        if (widget.popupMedia.alternativeText.isNotEmpty)
+                          Padding(
+                            padding: const EdgeInsets.all(8),
+                            child: Text(
+                              widget.popupMedia.alternativeText,
+                              maxLines: 2,
+                              style: Theme.of(context).textTheme.bodyMedium,
+                              overflow: TextOverflow.ellipsis,
+                            ),
+                          ),
+                      ],
                     ),
                   );
                 },


### PR DESCRIPTION
If a PopupMedia has an image that can't be loaded, display the alternativeText (if it has any).

<img width="489" height="478" alt="Screenshot 2026-06-10 at 3 53 39 PM" src="https://github.com/user-attachments/assets/061b4838-d613-43d0-86bb-a44baa50941c" />

Compare with the JS MapViewer: https://arcgisruntime.maps.arcgis.com/apps/mapviewer/index.html?webmap=ed1a3697a4514caf93e89153063fd3aa
