### PR TITLE
Review BasemapGallery API ref

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@ ArcGIS Maps SDK for Flutter Toolkit contains ready-made widgets to simplify the 
 ## Toolkit components
 
 * Authenticator: A widget that handles authentication challenges. It will display a user interface when network and ArcGIS authentication challenges occur.
-* Basemap Gallery: A widget that displays a collection of basemaps, either from ArcGIS Online, a user-defined portal, or an array of custom basemap gallery items.
-* Building Explorer: A widget that enables a user to explore a building scene layer building model in a local scene view.
+* BasemapGallery: A widget that displays a collection of basemaps, either from ArcGIS Online, a user-defined portal, or an array of custom basemap gallery items.
+* BuildingExplorer: A widget that enables a user to explore a building scene layer building model in a local scene view.
 * Compass: A widget that visualizes the current rotation of the map or scene and allows the user to reset the rotation to north by tapping on it.
 * OverviewMap: A small inset map displaying a representation of the current viewpoint of the target map or scene.
 * PopupView: A widget that will display a pop-up for an individual feature. This includes showing the feature's title, attributes, custom description, media, and attachments.

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ ArcGIS Maps SDK for Flutter Toolkit contains ready-made widgets to simplify the 
 ## Toolkit components
 
 * Authenticator: A widget that handles authentication challenges. It will display a user interface when network and ArcGIS authentication challenges occur.
+* Basemap Gallery: A widget that displays a collection of basemaps, either from ArcGIS Online, a user-defined portal, or an array of custom basemap gallery items.
 * Building Explorer: A widget that enables a user to explore a building scene layer building model in a local scene view.
 * Compass: A widget that visualizes the current rotation of the map or scene and allows the user to reset the rotation to north by tapping on it.
 * OverviewMap: A small inset map displaying a representation of the current viewpoint of the target map or scene.

--- a/lib/arcgis_maps_toolkit.dart
+++ b/lib/arcgis_maps_toolkit.dart
@@ -18,8 +18,8 @@
 ///
 /// Toolkit components:
 /// * [Authenticator]: A widget that handles authentication challenges. It will display a user interface when network and ArcGIS authentication challenges occur.
-/// * [Basemap Gallery]: A widget that displays a collection of basemaps, either from ArcGIS Online, a user-defined portal, or an array of custom basemap gallery items.
-/// * [Building Explorer]: A widget that enables a user to explore a building scene layer building model in a local scene view.
+/// * [BasemapGallery]: A widget that displays a collection of basemaps, either from ArcGIS Online, a user-defined portal, or an array of custom basemap gallery items.
+/// * [BuildingExplorer]: A widget that enables a user to explore a building scene layer building model in a local scene view.
 /// * [Compass]: A widget that visualizes the current rotation of the map or scene and allows the user to reset the rotation to north by tapping on it.
 /// * [OverviewMap]: A small inset map displaying a representation of the current viewpoint of the target map or scene.
 /// * [PopupView]: A widget that will display a pop-up for an individual feature. This includes showing the feature's title, attributes, custom description, media, and attachments.

--- a/lib/arcgis_maps_toolkit.dart
+++ b/lib/arcgis_maps_toolkit.dart
@@ -18,7 +18,8 @@
 ///
 /// Toolkit components:
 /// * [Authenticator]: A widget that handles authentication challenges. It will display a user interface when network and ArcGIS authentication challenges occur.
-/// * [BasemapGallery]: A widget that displays a gallery of basemaps for the user to choose from and apply to a target map or scene.
+/// * [Basemap Gallery]: A widget that displays a collection of basemaps, either from ArcGIS Online, a user-defined portal, or an array of custom basemap gallery items.
+/// * [Building Explorer]: A widget that enables a user to explore a building scene layer building model in a local scene view.
 /// * [Compass]: A widget that visualizes the current rotation of the map or scene and allows the user to reset the rotation to north by tapping on it.
 /// * [OverviewMap]: A small inset map displaying a representation of the current viewpoint of the target map or scene.
 /// * [PopupView]: A widget that will display a pop-up for an individual feature. This includes showing the feature's title, attributes, custom description, media, and attachments.

--- a/lib/src/basemap_gallery/basemap_gallery.dart
+++ b/lib/src/basemap_gallery/basemap_gallery.dart
@@ -54,7 +54,7 @@ final class BasemapGallery extends StatefulWidget {
     this.onCurrentBasemapChanged,
   });
 
-  /// The [controller] driving this view.
+  /// The [controller] containing the state data and properties for this [BasemapGallery].
   final BasemapGalleryController controller;
 
   /// Default outer padding.

--- a/lib/src/basemap_gallery/basemap_gallery.dart
+++ b/lib/src/basemap_gallery/basemap_gallery.dart
@@ -16,21 +16,22 @@
 
 part of '../../../arcgis_maps_toolkit.dart';
 
-/// The [BasemapGallery] widget displays a collection of basemaps from:
-/// * ArcGIS Online, 
-/// * a user-defined portal, 
+/// The [BasemapGallery] widget displays a collection of basemaps from one of:
+/// * ArcGIS Online,
+/// * a user-defined portal,
 /// * or an array of custom [BasemapGalleryItem] objects.
 ///
 /// # Overview
 /// The [BasemapGallery] widget enables users to browse a collection of
-/// basemaps and apply a selected basemap item to a connected [GeoModel] (such as an
+/// basemaps and apply a selected [BasemapGalleryItem] to a connected [GeoModel] (such as an
 /// [ArcGISMap] or [ArcGISScene]) via a [BasemapGalleryController].
 ///
 /// ## Features
-/// * Displays basemaps as [BasemapGalleryItem] objects in a grid or list layout. 
+/// * Displays basemaps as [BasemapGalleryItem] objects in a grid or list layout.
 /// * Option to automatically switch the layout based on available width using the [BasemapGalleryViewStyle] enum.
-/// * Displays a default thumbnail if a thumbnail is not available via the portal item, or is not manually set to the [BasemapGalleryItem].
+/// * Displays a name and thumbnail for each basemap.
 /// * Shows selection state and exposes selection events via the controller.
+/// * Can be configured to automatically change the basemap of a geo model based on user selection.
 ///
 /// ## Usage
 /// A [BasemapGallery] widget is created with the following parameters:

--- a/lib/src/basemap_gallery/basemap_gallery.dart
+++ b/lib/src/basemap_gallery/basemap_gallery.dart
@@ -16,46 +16,35 @@
 
 part of '../../../arcgis_maps_toolkit.dart';
 
-/// The [BasemapGallery] widget displays a gallery of basemap thumbnails.
+/// The [BasemapGallery] widget displays a collection of basemaps from:
+/// * ArcGIS Online, 
+/// * a user-defined portal, 
+/// * or an array of custom [BasemapGalleryItem] objects.
 ///
 /// # Overview
-/// [BasemapGallery] is a UI component that lets a user browse a collection of
-/// basemaps and apply a selection to a connected [GeoModel] (such as an
+/// The [BasemapGallery] widget enables users to browse a collection of
+/// basemaps and apply a selected basemap item to a connected [GeoModel] (such as an
 /// [ArcGISMap] or [ArcGISScene]) via a [BasemapGalleryController].
 ///
-/// The basemaps shown in the gallery are provided by the controller (defaults,
-/// a portal, or custom items), and the current selection is tracked by the
-/// controller.
-///
 /// ## Features
-/// * Displays basemaps as a grid, list, or automatically switches based on
-///   available width.
+/// * Displays basemaps as [BasemapGalleryItem] objects in a grid or list layout. 
+/// * Option to automatically switch the layout based on available width using the [BasemapGalleryViewStyle] enum.
+/// * Displays a default thumbnail if a thumbnail is not available via the portal item, or is not manually set to the [BasemapGalleryItem].
 /// * Shows selection state and exposes selection events via the controller.
 ///
 /// ## Usage
-/// Provide a [BasemapGalleryController] and place the gallery in your widget
-/// tree.
+/// A [BasemapGallery] widget is created with the following parameters:
+/// * controller: A property for the controller that contains state data for this widget.
+/// * onCurrentBasemapChanged: An optional callback that is called when a basemap item is tapped.
 ///
+/// The widget can be inserted into a widget tree by calling the constructor and supplying a [BasemapGalleryController] with an associated [GeoModel] (i.e. [ArcGISMap] or [ArcGISScene]) and an optional onCurrentBasemapChanged callback function.
 /// ```dart
-/// late final ArcGISMap _map;
-/// late final BasemapGalleryController _controller;
-///
-/// @override
-/// void initState() {
-///   super.initState();
-///   _map = ArcGISMap.withBasemapStyle(BasemapStyle.arcGISTopographic);
-///   _controller = BasemapGalleryController(geoModel: _map);
-/// }
-///
-/// @override
-/// Widget build(BuildContext context) {
-///   return BasemapGallery(
-///     controller: _controller,
-///     onCurrentBasemapChanged: (basemap) {
-///       debugPrint('Selected basemap: ${basemap.name}');
-///     },
-///   );
-/// }
+/// BasemapGallery(
+///   controller: BasemapGalleryController(geoModel: map),
+///   onCurrentBasemapChanged: (basemap) {
+///     // Optional: handle basemap changed event
+///   },
+/// );
 /// ```
 final class BasemapGallery extends StatefulWidget {
   /// Creates a [BasemapGallery] widget.

--- a/lib/src/basemap_gallery/basemap_gallery_controller.dart
+++ b/lib/src/basemap_gallery/basemap_gallery_controller.dart
@@ -87,9 +87,9 @@ final class BasemapGalleryController {
   ]);
 
   /// The associated [GeoModel]. This is either an [ArcGISMap] or [ArcGISScene].
-  /// Associate a geo model with the [BasemapGalleryController] to automatically apply the selected basemap to the map or scene.
+  /// Associate a [GeoModel] with the [BasemapGalleryController] to automatically apply the selected basemap to the map or scene.
   ///
-  /// If the geo model is not loaded when set, it will be loaded by the [BasemapGalleryController].
+  /// If the [GeoModel] is not loaded when set, it will be loaded by the [BasemapGalleryController].
   GeoModel? get geoModel => _geoModel;
 
   set geoModel(GeoModel? value) {

--- a/lib/src/basemap_gallery/basemap_gallery_controller.dart
+++ b/lib/src/basemap_gallery/basemap_gallery_controller.dart
@@ -16,7 +16,7 @@
 
 part of '../../arcgis_maps_toolkit.dart';
 
-/// The [BasemapGalleryController] contains the state data and properties for the [BasemapGallery] it is associated with.
+/// The [BasemapGalleryController] contains the state data and properties for the associated [BasemapGallery].
 /// The controller is used to define the list of [BasemapGalleryItem] to display within the [BasemapGallery], manage the view style of the gallery, and
 /// listen to events when the current basemap changes.
 /// Once the [BasemapGalleryController] is configured, it is used to construct the [BasemapGallery] widget.

--- a/lib/src/basemap_gallery/basemap_gallery_controller.dart
+++ b/lib/src/basemap_gallery/basemap_gallery_controller.dart
@@ -16,24 +16,24 @@
 
 part of '../../arcgis_maps_toolkit.dart';
 
-/// The [BasemapGalleryController] contains the state data and properties for an active [BasemapGallery].
+/// The [BasemapGalleryController] contains the state data and properties for the [BasemapGallery] it is associated with.
 /// The controller is used to define the list of [BasemapGalleryItem] to display within the [BasemapGallery], manage the view style of the gallery, and
 /// listen to events when the current basemap changes.
 /// Once the [BasemapGalleryController] is configured, it is used to construct the [BasemapGallery] widget.
 final class BasemapGalleryController {
   /// Creates a [BasemapGalleryController] with default basemaps from ArcGIS Online's developer basemaps.
+  /// Provide a [GeoModel] to automatically apply the [BasemapGalleryController.currentBasemap] to the respective map or scene.
   ///
   /// These basemaps are secured and typically require an API key or named-user authentication.
-  /// Provide a [GeoModel] to automatically apply the [BasemapGalleryController.currentBasemap] to the respective map or scene.
   BasemapGalleryController({this._geoModel}) : _portal = null {
     _initFromGeoModel();
     unawaited(_populateDefaultBasemaps());
   }
 
   /// Creates a [BasemapGalleryController] using basemaps from the provided [Portal].
+  /// Provide a [GeoModel] to automatically apply the [BasemapGalleryController.currentBasemap] to the respective map or scene.
   ///
   /// If the [portal] is valid, the controller fetches basemaps from the portal asynchronously and populates the [gallery].
-  /// Provide a [GeoModel] to automatically apply the [BasemapGalleryController.currentBasemap] to the respective map or scene.
   BasemapGalleryController.withPortal(Portal portal, {this._geoModel})
     : _portal = portal {
     _initFromGeoModel();
@@ -97,7 +97,7 @@ final class BasemapGalleryController {
     _initFromGeoModel();
   }
 
-  /// The portal used to populate the [gallery], if set in the constructor.
+  /// The portal used to populate the [gallery], if provided in the constructor.
   Portal? get portal => _portal;
 
   /// Called after a basemap selection is applied.

--- a/lib/src/basemap_gallery/basemap_gallery_controller.dart
+++ b/lib/src/basemap_gallery/basemap_gallery_controller.dart
@@ -17,8 +17,8 @@
 part of '../../arcgis_maps_toolkit.dart';
 
 /// The [BasemapGalleryController] contains the state data and properties for an active [BasemapGallery].
-/// The controller is used to define the [BasemapGalleryItems] to display within the [BasemapGallery], manage the view style of the gallery, and 
-/// listen to events when the current basemap changes. 
+/// The controller is used to define the list of [BasemapGalleryItem] to display within the [BasemapGallery], manage the view style of the gallery, and
+/// listen to events when the current basemap changes.
 /// Once the [BasemapGalleryController] is configured, it is used to construct the [BasemapGallery] widget.
 final class BasemapGalleryController {
   /// Creates a [BasemapGalleryController] with default basemaps from ArcGIS Online's developer basemaps.

--- a/lib/src/basemap_gallery/basemap_gallery_controller.dart
+++ b/lib/src/basemap_gallery/basemap_gallery_controller.dart
@@ -16,30 +16,32 @@
 
 part of '../../arcgis_maps_toolkit.dart';
 
-/// Controls the state and behavior of a [BasemapGallery].
+/// The [BasemapGalleryController] contains the state data and properties for an active [BasemapGallery].
+/// The controller is used to define the [BasemapGalleryItems] to display within the [BasemapGallery], manage the view style of the gallery, and 
+/// listen to events when the current basemap changes. 
+/// Once the [BasemapGalleryController] is configured, it is used to construct the [BasemapGallery] widget.
 final class BasemapGalleryController {
-  /// Creates a gallery with default basemaps.
+  /// Creates a [BasemapGalleryController] with default basemaps from ArcGIS Online's developer basemaps.
   ///
-  /// If no custom items or portal is provided, this controller loads ArcGIS
-  /// Online's developer basemaps by default. These basemaps are secured and
-  /// typically require an API key or named-user authentication.
+  /// These basemaps are secured and typically require an API key or named-user authentication.
+  /// Provide a [GeoModel] to automatically apply the [BasemapGalleryController.currentBasemap] to the respective map or scene.
   BasemapGalleryController({this._geoModel}) : _portal = null {
     _initFromGeoModel();
     unawaited(_populateDefaultBasemaps());
   }
 
-  /// Creates a gallery using basemaps from a [Portal].
+  /// Creates a [BasemapGalleryController] using basemaps from the provided [Portal].
   ///
-  /// If [portal] is valid, the controller fetches portal basemaps asynchronously
-  /// and copies them into [gallery].
-  ///
+  /// If the [portal] is valid, the controller fetches basemaps from the portal asynchronously and populates the [gallery].
+  /// Provide a [GeoModel] to automatically apply the [BasemapGalleryController.currentBasemap] to the respective map or scene.
   BasemapGalleryController.withPortal(Portal portal, {this._geoModel})
     : _portal = portal {
     _initFromGeoModel();
     unawaited(_populateFromPortal());
   }
 
-  /// Creates a gallery using provided [items].
+  /// Creates a [BasemapGalleryController] using the provided custom list of [BasemapGalleryItem].
+  /// Provide a [GeoModel] to automatically apply the [BasemapGalleryController.currentBasemap] to the respective map or scene.
   BasemapGalleryController.withItems({
     required List<BasemapGalleryItem> items,
     this._geoModel,
@@ -84,10 +86,10 @@ final class BasemapGalleryController {
     _currentBasemapNotifier,
   ]);
 
-  /// The associated geo model.
+  /// The associated [GeoModel]. This is either an [ArcGISMap] or [ArcGISScene].
+  /// Associate a geo model with the [BasemapGalleryController] to automatically apply the selected basemap to the map or scene.
   ///
-  /// If it is not loaded when set, it will be loaded immediately.
-  ///
+  /// If the geo model is not loaded when set, it will be loaded by the [BasemapGalleryController].
   GeoModel? get geoModel => _geoModel;
 
   set geoModel(GeoModel? value) {
@@ -95,25 +97,25 @@ final class BasemapGalleryController {
     _initFromGeoModel();
   }
 
-  /// The portal used for basemaps when constructed with a portal.
+  /// The portal used to populate the [gallery], if set in the constructor.
   Portal? get portal => _portal;
 
   /// Called after a basemap selection is applied.
   ValueChanged<Basemap>? onCurrentBasemapChanged;
 
-  /// The currently applied basemap on the associated [GeoModel].
+  /// The basemap that is currently applied on the associated [GeoModel].
   Basemap? get currentBasemap => _currentBasemapNotifier.value?.basemap;
 
   BasemapGalleryItem? get _currentBasemapItem => _currentBasemapNotifier.value;
 
-  /// The list of basemaps visible in the gallery.
+  /// The list of basemap gallery items associated with this [BasemapGalleryController].
   ///
-  /// Items added or removed from this list will update the gallery.
+  /// When the controller is attached to a [BasemapGallery] widget, items added or removed from this list will update the visible gallery.
   List<BasemapGalleryItem> get gallery => _gallery;
 
   bool get _isFetchingBasemaps => _isFetchingBasemapsNotifier.value;
 
-  /// Current view style.
+  /// The current view style for the basemap gallery.
   BasemapGalleryViewStyle get viewStyle => _viewStyleNotifier.value;
 
   set viewStyle(BasemapGalleryViewStyle style) {

--- a/lib/src/basemap_gallery/basemap_gallery_item.dart
+++ b/lib/src/basemap_gallery/basemap_gallery_item.dart
@@ -16,16 +16,16 @@
 
 part of '../../arcgis_maps_toolkit.dart';
 
-/// An element in a basemap gallery.
+/// A class representing an item within a basemap gallery.
 ///
 /// Fallback rules:
-/// - If `thumbnail`/`tooltip` overrides are provided and valid, they are used.
-/// - Otherwise, fall back to the basemap's associated [Item] (if present).
+/// - Thumbnail: If [BasemapGalleryItem.thumbnail] is set and valid, it overrides the default. Otherwise, defaults to the basemap's associated [PortalItem] thumbnail, if it exists. 
+/// - Tooltip: If [BasemapGalleryItem.tooltip] is set and valid, it overrides the default. Otherwise, defaults to the basemap's associated [PortalItem] description, if it exists.
 final class BasemapGalleryItem {
   /// Creates a [BasemapGalleryItem].
   ///
-  /// If [thumbnail] or [tooltip] are not provided (or are empty for [tooltip]),
-  /// values from the basemap's associated [Item] are used as fallbacks.
+  /// If [thumbnail] is not provided, defaults to the basemap's associated [PortalItem] thumbnail, if it exists.
+  /// If [tooltip] is not provided, or is empty, defaults to the basemap's associated [PortalItem] description, if it exists.
   BasemapGalleryItem({
     required this._basemap,
     ArcGISImage? thumbnail,
@@ -61,26 +61,25 @@ final class BasemapGalleryItem {
     _spatialReferenceStatusNotifier,
   ]);
 
-  /// The basemap for this gallery item.
+  /// The basemap for this basemap gallery item.
   Basemap get basemap => _basemap;
 
-  /// The name of this basemap.
+  /// The name of this basemap from the basemap's associated [PortalItem] name, if it exists.
   String get name => _nameNotifier.value;
 
   /// The thumbnail to display for this gallery item.
+  /// The thumbnail can be set manually, otherwise defaults to the basemap's associated [PortalItem] thumbnail, if it exists.
   ArcGISImage? get thumbnail => _thumbnailNotifier.value;
 
-  /// Sets the thumbnail for this gallery item.
+  /// Sets the provided thumbnail image to this basemap gallery item.
   ///
-  /// Use this to apply thumbnails that are created asynchronously, such as with
-  /// `ArcGISImage.fromAsset`. If [image] is `null`, the item falls back to the
-  /// basemap item's thumbnail.
+  /// If [image] is `null`, defaults to the basemap's associated [PortalItem] thumbnail, if it exists.
   void setThumbnail({ArcGISImage? image}) {
     _thumbnailOverride = image;
     _recomputeDerivedFields();
   }
 
-  /// The tooltip to display for this gallery item.
+  /// The tooltip for this basemap gallery item.
   String? get tooltip => _tooltipNotifier.value;
 
   bool get _isBasemapLoading => _isBasemapLoadingNotifier.value;

--- a/lib/src/basemap_gallery/basemap_gallery_item.dart
+++ b/lib/src/basemap_gallery/basemap_gallery_item.dart
@@ -19,11 +19,10 @@ part of '../../arcgis_maps_toolkit.dart';
 /// A class representing an item within a basemap gallery.
 ///
 /// Fallback rules:
-/// - Thumbnail: If [BasemapGalleryItem.thumbnail] is set and valid, it overrides the default. Otherwise, defaults to the basemap's associated [PortalItem] thumbnail, if it exists. 
+/// - Thumbnail: If [BasemapGalleryItem.thumbnail] is set and valid, it overrides the default. Otherwise, defaults to the basemap's associated [PortalItem] thumbnail, if it exists.
 /// - Tooltip: If [BasemapGalleryItem.tooltip] is set and valid, it overrides the default. Otherwise, defaults to the basemap's associated [PortalItem] description, if it exists.
 final class BasemapGalleryItem {
-  /// Creates a [BasemapGalleryItem].
-  ///
+  /// Creates a [BasemapGalleryItem] using the provided basemap.
   /// If [thumbnail] is not provided, defaults to the basemap's associated [PortalItem] thumbnail, if it exists.
   /// If [tooltip] is not provided, or is empty, defaults to the basemap's associated [PortalItem] description, if it exists.
   BasemapGalleryItem({
@@ -79,7 +78,7 @@ final class BasemapGalleryItem {
     _recomputeDerivedFields();
   }
 
-  /// The tooltip for this basemap gallery item.
+  /// The tooltip for this basemap gallery item, as provided in the constructor.
   String? get tooltip => _tooltipNotifier.value;
 
   bool get _isBasemapLoading => _isBasemapLoadingNotifier.value;

--- a/lib/src/basemap_gallery/basemap_gallery_view_style.dart
+++ b/lib/src/basemap_gallery/basemap_gallery_view_style.dart
@@ -16,12 +16,12 @@
 
 part of '../../arcgis_maps_toolkit.dart';
 
-// The view style of the basemap gallery.
+/// An enum representing the view style of a basemap gallery.
 enum BasemapGalleryViewStyle {
-  // Display as a grid when width allows; otherwise display as a list.
+  /// Display as a grid when width allows; otherwise display as a list.
   automatic,
-  // Display as a grid.
+  /// Display as a grid.
   grid,
-  // Display as a list.
+  /// Display as a list.
   list,
 }


### PR DESCRIPTION
This PR reviews the BasemapGallery API ref:
- Adds the basemap gallery to the listings for the toolkit repo / package
- Reviews the wording of each of the classes
- I also identified a couple of things that could use some clarification - these are written up as new issues so the API ref for those specific things can be re-reviewed then:
   - The management of the "basemap changed" process (and potential naming)
   - The spatial reference enum being publicly exposed