### PR TITLE
BasemapGallery: review onBasemapChanged events

### DIFF
--- a/example/lib/example_basemap_gallery.dart
+++ b/example/lib/example_basemap_gallery.dart
@@ -49,7 +49,7 @@ class _ExampleBasemapGalleryState extends State<ExampleBasemapGallery> {
 
   late final ArcGISMap _map;
   final _selectedBasemapName = ValueNotifier<String>('');
-  late final BasemapGalleryController _controller;
+  late final BasemapGalleryController _basemapGalleryController;
 
   @override
   void initState() {
@@ -67,7 +67,7 @@ class _ExampleBasemapGalleryState extends State<ExampleBasemapGallery> {
 
     final galleryItems = _makeBasemapGalleryItems();
 
-    _controller = BasemapGalleryController.withItems(
+    _basemapGalleryController = BasemapGalleryController.withItems(
       geoModel: _map,
       items: galleryItems,
     )..viewStyle = BasemapGalleryViewStyle.grid;
@@ -75,8 +75,9 @@ class _ExampleBasemapGalleryState extends State<ExampleBasemapGallery> {
     // Asset-backed ArcGISImage values are created asynchronously.
     unawaited(_setDefaultThumbnail(galleryItems.last));
 
-    _selectedBasemapName.value = _controller.currentBasemap?.name ?? '';
-    _controller.onBasemapChanged = (basemap) {
+    _selectedBasemapName.value =
+        _basemapGalleryController.currentBasemap?.name ?? '';
+    _basemapGalleryController.onBasemapChanged = (basemap) {
       _selectedBasemapName.value = basemap.name;
     };
   }
@@ -84,7 +85,7 @@ class _ExampleBasemapGalleryState extends State<ExampleBasemapGallery> {
   @override
   void dispose() {
     _selectedBasemapName.dispose();
-    _controller.dispose();
+    _basemapGalleryController.dispose();
     super.dispose();
   }
 
@@ -172,17 +173,7 @@ class _ExampleBasemapGalleryState extends State<ExampleBasemapGallery> {
               Expanded(
                 child: Padding(
                   padding: const EdgeInsets.all(8),
-                  child: BasemapGallery(
-                    controller: _controller,
-                    onBasemapTapped: (basemap) {
-                      ScaffoldMessenger.of(context).showSnackBar(
-                        SnackBar(
-                          content: Text('Basemap changed to: ${basemap.name}'),
-                          duration: const Duration(seconds: 2),
-                        ),
-                      );
-                    },
-                  ),
+                  child: BasemapGallery(controller: _basemapGalleryController),
                 ),
               ),
             ],

--- a/example/lib/example_basemap_gallery.dart
+++ b/example/lib/example_basemap_gallery.dart
@@ -76,7 +76,7 @@ class _ExampleBasemapGalleryState extends State<ExampleBasemapGallery> {
     unawaited(_setDefaultThumbnail(galleryItems.last));
 
     _selectedBasemapName.value = _controller.currentBasemap?.name ?? '';
-    _controller.onCurrentBasemapChanged = (basemap) {
+    _controller.onBasemapChanged = (basemap) {
       _selectedBasemapName.value = basemap.name;
     };
   }
@@ -174,7 +174,7 @@ class _ExampleBasemapGalleryState extends State<ExampleBasemapGallery> {
                   padding: const EdgeInsets.all(8),
                   child: BasemapGallery(
                     controller: _controller,
-                    onCurrentBasemapChanged: (basemap) {
+                    onBasemapTapped: (basemap) {
                       ScaffoldMessenger.of(context).showSnackBar(
                         SnackBar(
                           content: Text('Basemap changed to: ${basemap.name}'),

--- a/lib/src/basemap_gallery/basemap_gallery.dart
+++ b/lib/src/basemap_gallery/basemap_gallery.dart
@@ -40,7 +40,6 @@ part of '../../../arcgis_maps_toolkit.dart';
 ///
 /// The widget can be inserted into a widget tree by calling the constructor and supplying a [BasemapGalleryController] with an associated [GeoModel] (i.e. [ArcGISMap] or [ArcGISScene]) and an optional onCurrentBasemapChanged callback function.
 /// ```dart
-<<<<<<< HEAD
 /// late final ArcGISMap _map;
 /// late final BasemapGalleryController _controller;
 ///

--- a/lib/src/basemap_gallery/basemap_gallery.dart
+++ b/lib/src/basemap_gallery/basemap_gallery.dart
@@ -40,19 +40,31 @@ part of '../../../arcgis_maps_toolkit.dart';
 ///
 /// The widget can be inserted into a widget tree by calling the constructor and supplying a [BasemapGalleryController] with an associated [GeoModel] (i.e. [ArcGISMap] or [ArcGISScene]) and an optional onCurrentBasemapChanged callback function.
 /// ```dart
-/// BasemapGallery(
-///   controller: BasemapGalleryController(geoModel: map),
-///   onCurrentBasemapChanged: (basemap) {
-///     // Optional: handle basemap changed event
-///   },
-/// );
+/// late final ArcGISMap _map;
+/// late final BasemapGalleryController _controller;
+///
+/// @override
+/// void initState() {
+///   super.initState();
+///   _map = ArcGISMap.withBasemapStyle(BasemapStyle.arcGISTopographic);
+///   _controller = BasemapGalleryController(geoModel: _map);
+///   _controller.onBasemapChanged = (basemap) {
+///     debugPrint('Selected basemap: ${basemap.name}');
+///   };
+/// }
+///
+/// @override
+/// Widget build(BuildContext context) {
+///   return BasemapGallery(
+///     controller: _controller,
+///   );
+/// }
 /// ```
 final class BasemapGallery extends StatefulWidget {
   /// Creates a [BasemapGallery] widget.
   const BasemapGallery({
     required this.controller,
     super.key,
-    this.onCurrentBasemapChanged,
   });
 
   /// The [controller] containing the state data and properties for this [BasemapGallery].
@@ -66,12 +78,6 @@ final class BasemapGallery extends StatefulWidget {
 
   /// Default grid tile spacing.
   static const double _gridSpacing = 8;
-
-  /// [onCurrentBasemapChanged] is called when a basemap is tapped.
-  /// Not called for loading/error items. Selection may show a
-  /// spatial reference mismatch dialog. For applied selection, listen to
-  /// [BasemapGalleryController.currentBasemap].
-  final ValueChanged<Basemap>? onCurrentBasemapChanged;
 
   @override
   State<BasemapGallery> createState() => _BasemapGalleryState();
@@ -271,10 +277,6 @@ final class _BasemapGalleryState extends State<BasemapGallery> {
     }
 
     await widget.controller._select(item);
-    final current = widget.controller._currentBasemapItem;
-    if (current == null) return;
-    if (!identical(current.basemap, item.basemap)) return;
-    widget.onCurrentBasemapChanged?.call(current.basemap);
   }
 }
 

--- a/lib/src/basemap_gallery/basemap_gallery.dart
+++ b/lib/src/basemap_gallery/basemap_gallery.dart
@@ -40,6 +40,7 @@ part of '../../../arcgis_maps_toolkit.dart';
 ///
 /// The widget can be inserted into a widget tree by calling the constructor and supplying a [BasemapGalleryController] with an associated [GeoModel] (i.e. [ArcGISMap] or [ArcGISScene]) and an optional onCurrentBasemapChanged callback function.
 /// ```dart
+<<<<<<< HEAD
 /// late final ArcGISMap _map;
 /// late final BasemapGalleryController _controller;
 ///

--- a/lib/src/basemap_gallery/basemap_gallery.dart
+++ b/lib/src/basemap_gallery/basemap_gallery.dart
@@ -40,23 +40,10 @@ part of '../../../arcgis_maps_toolkit.dart';
 ///
 /// The widget can be inserted into a widget tree by calling the constructor and supplying a [BasemapGalleryController] with an associated [GeoModel] (i.e. [ArcGISMap] or [ArcGISScene]) and an optional onCurrentBasemapChanged callback function.
 /// ```dart
-/// late final ArcGISMap _map;
-/// late final BasemapGalleryController _controller;
-///
-/// @override
-/// void initState() {
-///   super.initState();
-///   _map = ArcGISMap.withBasemapStyle(BasemapStyle.arcGISTopographic);
-///   _controller = BasemapGalleryController(geoModel: _map);
-///   _controller.onBasemapChanged = (basemap) {
-///     debugPrint('Selected basemap: ${basemap.name}');
-///   };
-/// }
-///
 /// @override
 /// Widget build(BuildContext context) {
 ///   return BasemapGallery(
-///     controller: _controller,
+///     controller: BasemapGalleryController(geoModel: map),
 ///   );
 /// }
 /// ```

--- a/lib/src/basemap_gallery/basemap_gallery.dart
+++ b/lib/src/basemap_gallery/basemap_gallery.dart
@@ -36,9 +36,8 @@ part of '../../../arcgis_maps_toolkit.dart';
 /// ## Usage
 /// A [BasemapGallery] widget is created with the following parameters:
 /// * controller: A property for the controller that contains state data for this widget.
-/// * onCurrentBasemapChanged: An optional callback that is called when a basemap item is tapped.
 ///
-/// The widget can be inserted into a widget tree by calling the constructor and supplying a [BasemapGalleryController] with an associated [GeoModel] (i.e. [ArcGISMap] or [ArcGISScene]) and an optional onCurrentBasemapChanged callback function.
+/// The widget can be inserted into a widget tree by calling the constructor and supplying a [BasemapGalleryController] with an associated [GeoModel] (i.e. [ArcGISMap] or [ArcGISScene]).
 /// ```dart
 /// @override
 /// Widget build(BuildContext context) {

--- a/lib/src/basemap_gallery/basemap_gallery.dart
+++ b/lib/src/basemap_gallery/basemap_gallery.dart
@@ -62,10 +62,7 @@ part of '../../../arcgis_maps_toolkit.dart';
 /// ```
 final class BasemapGallery extends StatefulWidget {
   /// Creates a [BasemapGallery] widget.
-  const BasemapGallery({
-    required this.controller,
-    super.key,
-  });
+  const BasemapGallery({required this.controller, super.key});
 
   /// The [controller] containing the state data and properties for this [BasemapGallery].
   final BasemapGalleryController controller;

--- a/lib/src/basemap_gallery/basemap_gallery_controller.dart
+++ b/lib/src/basemap_gallery/basemap_gallery_controller.dart
@@ -101,7 +101,7 @@ final class BasemapGalleryController {
   Portal? get portal => _portal;
 
   /// Called after a basemap selection is applied.
-  ValueChanged<Basemap>? onCurrentBasemapChanged;
+  ValueChanged<Basemap>? onBasemapChanged;
 
   /// The basemap that is currently applied on the associated [GeoModel].
   Basemap? get currentBasemap => _currentBasemapNotifier.value?.basemap;
@@ -129,7 +129,7 @@ final class BasemapGalleryController {
   /// - Ensure the associated [GeoModel] is loaded (if provided).
   /// - Check spatial reference compatibility when a [GeoModel] is provided.
   /// - Update [currentBasemap], synchronize [GeoModel.basemap], and emit on
-  ///   [onCurrentBasemapChanged] when selection succeeds.
+  ///   [onBasemapChanged] when selection succeeds.
   Future<void> _select(BasemapGalleryItem item) async {
     if (item._isBasemapLoading) return;
     if (item._loadBasemapError != null) return;
@@ -158,7 +158,7 @@ final class BasemapGalleryController {
       gm.basemap = item.basemap;
     }
 
-    onCurrentBasemapChanged?.call(item.basemap);
+    onBasemapChanged?.call(item.basemap);
   }
 
   /// Disposes resources.

--- a/lib/src/basemap_gallery/basemap_gallery_view_style.dart
+++ b/lib/src/basemap_gallery/basemap_gallery_view_style.dart
@@ -20,8 +20,10 @@ part of '../../arcgis_maps_toolkit.dart';
 enum BasemapGalleryViewStyle {
   /// Display as a grid when width allows; otherwise display as a list.
   automatic,
+
   /// Display as a grid.
   grid,
+
   /// Display as a list.
   list,
 }


### PR DESCRIPTION
Removing`BasemapGallery.onCurrentBasemapChanged/onBasemapTapped` and keeping only Controller.onBasemapChanged as the single basemap-change event.