### PR TITLE
Modify Compass 3D return to north behavior

### DIFF
--- a/lib/src/compass/compass.dart
+++ b/lib/src/compass/compass.dart
@@ -169,90 +169,11 @@ class _CompassState extends State<Compass> {
   Future<void> onPressed() async {
     switch (_controller) {
       case final ArcGISMapViewController controller:
-        controller.setViewpointRotation(angleDegrees: 0);
+        _onPressedMapView(controller);
       case final ArcGISSceneViewController controller:
-        final currentCamera = controller.getCurrentViewpointCamera();
-        if (currentCamera.pitch < 0.1) {
-          // Orbit controller gets confused when camera is looking straight down.
-          controller.setViewpointCameraAnimated(
-            camera: currentCamera.rotateTo(
-              heading: 0,
-              pitch: currentCamera.pitch,
-              roll: currentCamera.roll,
-            ),
-          );
-        } else {
-          // Pitch is great enough to use an orbit controller.
-          // Get the target point.
-          final targetPt = await _getSceneCenterPoint(context);
-          if (targetPt == null || targetPt.isEmpty) {
-            // If no target point, just set the camera heading to 0 and update the view.
-            controller.setViewpointCameraAnimated(
-              camera: currentCamera.rotateTo(
-                heading: 0,
-                pitch: currentCamera.pitch,
-                roll: currentCamera.roll,
-              ),
-            );
-            return;
-          }
-
-          // Configure and set an OrbitLocationCameraController.
-          final currentCameraController = controller.cameraController;
-          final orbitalCameraController =
-              OrbitLocationCameraController.withTargetPositionAndCameraPosition(
-                targetLocation: targetPt,
-                cameraPoint: currentCamera.location,
-              );
-          controller.cameraController = orbitalCameraController;
-
-          // Move the camera to the new position.
-          final normalizedCurrentHeading = currentCamera.heading % 360;
-          final headingDelta = normalizedCurrentHeading < 180
-              ? -normalizedCurrentHeading
-              : 360 - normalizedCurrentHeading;
-
-          try {
-            await orbitalCameraController.moveCamera(
-              distanceDelta: 0,
-              headingDelta: headingDelta,
-              pitchDelta: 0,
-              duration: 1,
-            );
-          } finally {
-            // Reset the camera controller.
-            controller.cameraController = currentCameraController;
-          }
-        }
+        await _onPressedSceneView(controller);
       case final ArcGISLocalSceneViewController controller:
-        final currentCamera = controller.getCurrentViewpointCamera();
-        // Get the target point.
-        final targetPt = await _getSceneCenterPoint(context);
-        if (targetPt == null || targetPt.isEmpty) {
-          // If no target point, just set the camera heading to 0 and update the view.
-          controller.setViewpointCameraAnimated(
-            camera: currentCamera.rotateTo(
-              heading: 0,
-              pitch: currentCamera.pitch,
-              roll: currentCamera.roll,
-            ),
-          );
-          return;
-        }
-
-        final normalizedCurrentHeading = currentCamera.heading % 360;
-        final headingDelta = normalizedCurrentHeading < 180
-            ? -normalizedCurrentHeading
-            : 360 - normalizedCurrentHeading;
-
-        controller.setViewpointCameraAnimated(
-          camera: currentCamera.rotateAround(
-            targetPoint: targetPt,
-            deltaHeading: -headingDelta,
-            deltaPitch: 0,
-            deltaRoll: 0,
-          ),
-        );
+        await _onPressedLocalSceneView(controller);
     }
   }
 
@@ -274,6 +195,99 @@ class _CompassState extends State<Compass> {
             width: 1.25,
           ),
         ),
+      ),
+    );
+  }
+
+  void _onPressedMapView(ArcGISMapViewController controller) {
+    controller.setViewpointRotation(angleDegrees: 0);
+  }
+
+  Future<void> _onPressedSceneView(ArcGISSceneViewController controller) async {
+    final currentCamera = controller.getCurrentViewpointCamera();
+    if (currentCamera.pitch < 0.1) {
+      // Orbit controller gets confused when camera is looking straight down.
+      controller.setViewpointCameraAnimated(
+        camera: currentCamera.rotateTo(
+          heading: 0,
+          pitch: currentCamera.pitch,
+          roll: currentCamera.roll,
+        ),
+      );
+    } else {
+      // Pitch is great enough to use an orbit controller.
+      // Get the target point.
+      final targetPt = await _getSceneCenterPoint(context);
+      if (targetPt == null || targetPt.isEmpty) {
+        // If no target point, just set the camera heading to 0 and update the view.
+        controller.setViewpointCameraAnimated(
+          camera: currentCamera.rotateTo(
+            heading: 0,
+            pitch: currentCamera.pitch,
+            roll: currentCamera.roll,
+          ),
+        );
+        return;
+      }
+
+      // Configure and set an OrbitLocationCameraController.
+      final currentCameraController = controller.cameraController;
+      final orbitalCameraController =
+          OrbitLocationCameraController.withTargetPositionAndCameraPosition(
+            targetLocation: targetPt,
+            cameraPoint: currentCamera.location,
+          );
+      controller.cameraController = orbitalCameraController;
+
+      // Move the camera to the new position.
+      final normalizedCurrentHeading = currentCamera.heading % 360;
+      final headingDelta = normalizedCurrentHeading < 180
+          ? -normalizedCurrentHeading
+          : 360 - normalizedCurrentHeading;
+
+      try {
+        await orbitalCameraController.moveCamera(
+          distanceDelta: 0,
+          headingDelta: headingDelta,
+          pitchDelta: 0,
+          duration: 1,
+        );
+      } finally {
+        // Reset the camera controller.
+        controller.cameraController = currentCameraController;
+      }
+    }
+  }
+
+  Future<void> _onPressedLocalSceneView(
+    ArcGISLocalSceneViewController controller,
+  ) async {
+    final currentCamera = controller.getCurrentViewpointCamera();
+    // Get the target point.
+    final targetPt = await _getSceneCenterPoint(context);
+    if (targetPt == null || targetPt.isEmpty) {
+      // If no target point, just set the camera heading to 0 and update the view.
+      controller.setViewpointCameraAnimated(
+        camera: currentCamera.rotateTo(
+          heading: 0,
+          pitch: currentCamera.pitch,
+          roll: currentCamera.roll,
+        ),
+      );
+      return;
+    }
+
+    final normalizedCurrentHeading = currentCamera.heading % 360;
+    final headingDelta = normalizedCurrentHeading < 180
+        ? -normalizedCurrentHeading
+        : 360 - normalizedCurrentHeading;
+
+    controller.setViewpointCameraAnimated(
+      camera: currentCamera.rotateAround(
+        targetPoint: targetPt,
+        deltaHeading: -headingDelta,
+        deltaPitch: 0,
+        deltaRoll: 0,
       ),
     );
   }

--- a/lib/src/compass/compass.dart
+++ b/lib/src/compass/compass.dart
@@ -201,15 +201,18 @@ class _CompassState extends State<Compass> {
           final headingDelta = normalizedCurrentHeading < 180
               ? -normalizedCurrentHeading
               : 360 - normalizedCurrentHeading;
-          await orbitalCameraController.moveCamera(
-            distanceDelta: 0,
-            headingDelta: headingDelta,
-            pitchDelta: 0,
-            duration: 1,
-          );
 
-          // Reset the camera controller.
-          controller.cameraController = currentCameraController;
+          try {
+            await orbitalCameraController.moveCamera(
+              distanceDelta: 0,
+              headingDelta: headingDelta,
+              pitchDelta: 0,
+              duration: 1,
+            );
+          } finally {
+            // Reset the camera controller.
+            controller.cameraController = currentCameraController;
+          }
         }
       case final ArcGISLocalSceneViewController controller:
         // Get the target point.

--- a/lib/src/compass/compass.dart
+++ b/lib/src/compass/compass.dart
@@ -91,6 +91,9 @@ class Compass extends StatefulWidget {
 class _CompassState extends State<Compass> {
   late GeoViewController _controller;
 
+  // TODO: get rid of this graphics stuff
+  final _centerPointOverlay = GraphicsOverlay();
+
   StreamSubscription<double>? _rotationSubscription;
   StreamSubscription<void>? _viewpointSubscription;
 
@@ -114,6 +117,9 @@ class _CompassState extends State<Compass> {
           setState(() => _angleDegrees = rotation);
         });
       case final ArcGISSceneViewController controller:
+        // TODO: get rid of this graphics stuff
+        controller.graphicsOverlays.add(_centerPointOverlay);
+
         _angleDegrees = controller.getCurrentViewpointCamera().heading;
         _viewpointSubscription = controller.onViewpointChanged.listen((_) {
           final heading = controller.getCurrentViewpointCamera().heading;
@@ -166,28 +172,50 @@ class _CompassState extends State<Compass> {
     );
   }
 
-  void onPressed() {
+  Future<void> onPressed() async {
     switch (_controller) {
       case final ArcGISMapViewController controller:
         controller.setViewpointRotation(angleDegrees: 0);
       case final ArcGISSceneViewController controller:
         final currentCamera = controller.getCurrentViewpointCamera();
-        controller.setViewpointCameraAnimated(
-          camera: currentCamera.rotateTo(
-            heading: 0,
-            pitch: currentCamera.pitch,
-            roll: currentCamera.roll,
-          ),
+        // Get the target point.
+        // final targetPt = await _getCameraTargetPoint();
+        final targetPt = await _getSceneCenterPoint(context);
+        if (targetPt == null) return;
+
+        // Configure and set an OrbitLocationCameraController.
+        final currentCameraController = controller.cameraController;
+        final orbitalCameraController =
+            OrbitLocationCameraController.withTargetPositionAndCameraPosition(
+              targetLocation: targetPt,
+              cameraPoint: currentCamera.location,
+            );
+        controller.cameraController = orbitalCameraController;
+
+        // Move the camera to the new position.
+        final normalizedCurrentHeading = currentCamera.heading % 360;
+        final headingDelta = normalizedCurrentHeading < 180
+            ? -normalizedCurrentHeading
+            : 360 - normalizedCurrentHeading;
+        await orbitalCameraController.moveCamera(
+          distanceDelta: 0,
+          headingDelta: headingDelta,
+          pitchDelta: 0,
+          duration: 1,
         );
-      case final ArcGISLocalSceneViewController controller:
-        final currentCamera = controller.getCurrentViewpointCamera();
-        controller.setViewpointCameraAnimated(
-          camera: currentCamera.rotateTo(
-            heading: 0,
-            pitch: currentCamera.pitch,
-            roll: currentCamera.roll,
-          ),
-        );
+
+        // Reset the camera controller on the view.
+        controller.cameraController = currentCameraController;
+
+      // case final ArcGISLocalSceneViewController controller:
+      //   final currentCamera = controller.getCurrentViewpointCamera();
+      //   controller.setViewpointCameraAnimated(
+      //     camera: currentCamera.rotateTo(
+      //       heading: 0,
+      //       pitch: currentCamera.pitch,
+      //       roll: currentCamera.roll,
+      //     ),
+      //   );
     }
   }
 
@@ -211,5 +239,43 @@ class _CompassState extends State<Compass> {
         ),
       ),
     );
+  }
+
+  Future<ArcGISPoint?> _getSceneCenterPoint(BuildContext context) async {
+    // Get the center offset for the scene or local scene view
+    final renderBox = context.findRenderObject() as RenderBox?;
+    if (renderBox == null) return null;
+    final centerOffset = Offset(
+      renderBox.size.width / 2,
+      renderBox.size.height / 2,
+    );
+
+    final ArcGISPoint centerPoint;
+    if (_controller is ArcGISLocalSceneViewController) {
+      centerPoint = await (_controller as ArcGISLocalSceneViewController)
+          .screenToLocation(screen: centerOffset);
+    } else if (_controller is ArcGISSceneViewController) {
+      centerPoint = await (_controller as ArcGISSceneViewController)
+          .screenToLocation(screen: centerOffset);
+    } else {
+      // This function only works with local scene view and scene view controllers.
+      return null;
+    }
+
+    // TODO: get rid of this graphics stuff
+    final centerPointGraphic = Graphic(
+      geometry: centerPoint,
+      symbol: SimpleMarkerSceneSymbol(
+        style: .diamond,
+        color: Colors.yellow,
+        width: 10,
+        height: 10,
+        depth: 10,
+      ),
+    );
+    _centerPointOverlay.graphics.clear();
+    _centerPointOverlay.graphics.add(centerPointGraphic);
+
+    return centerPoint;
   }
 }

--- a/lib/src/compass/compass.dart
+++ b/lib/src/compass/compass.dart
@@ -178,35 +178,45 @@ class _CompassState extends State<Compass> {
         controller.setViewpointRotation(angleDegrees: 0);
       case final ArcGISSceneViewController controller:
         final currentCamera = controller.getCurrentViewpointCamera();
-        // Get the target point.
-        // final targetPt = await _getCameraTargetPoint();
-        final targetPt = await _getSceneCenterPoint(context);
-        if (targetPt == null) return;
+        if (currentCamera.pitch < 0.1) {
+          // Orbit controller gets confused when camera is looking straight down.
+          controller.setViewpointCameraAnimated(
+            camera: currentCamera.rotateTo(
+              heading: 0,
+              pitch: currentCamera.pitch,
+              roll: currentCamera.roll,
+            ),
+          );
+        } else {
+          // Pitch is great enough to use an orbit controller.
+          // Get the target point.
+          final targetPt = await _getSceneCenterPoint(context);
+          if (targetPt == null) return;
 
-        // Configure and set an OrbitLocationCameraController.
-        final currentCameraController = controller.cameraController;
-        final orbitalCameraController =
-            OrbitLocationCameraController.withTargetPositionAndCameraPosition(
-              targetLocation: targetPt,
-              cameraPoint: currentCamera.location,
-            );
-        controller.cameraController = orbitalCameraController;
+          // Configure and set an OrbitLocationCameraController.
+          final currentCameraController = controller.cameraController;
+          final orbitalCameraController =
+              OrbitLocationCameraController.withTargetPositionAndCameraPosition(
+                targetLocation: targetPt,
+                cameraPoint: currentCamera.location,
+              );
+          controller.cameraController = orbitalCameraController;
 
-        // Move the camera to the new position.
-        final normalizedCurrentHeading = currentCamera.heading % 360;
-        final headingDelta = normalizedCurrentHeading < 180
-            ? -normalizedCurrentHeading
-            : 360 - normalizedCurrentHeading;
-        await orbitalCameraController.moveCamera(
-          distanceDelta: 0,
-          headingDelta: headingDelta,
-          pitchDelta: 0,
-          duration: 1,
-        );
+          // Move the camera to the new position.
+          final normalizedCurrentHeading = currentCamera.heading % 360;
+          final headingDelta = normalizedCurrentHeading < 180
+              ? -normalizedCurrentHeading
+              : 360 - normalizedCurrentHeading;
+          await orbitalCameraController.moveCamera(
+            distanceDelta: 0,
+            headingDelta: headingDelta,
+            pitchDelta: 0,
+            duration: 1,
+          );
 
-        // Reset the camera controller on the view.
-        controller.cameraController = currentCameraController;
-
+          // Reset the camera controller.
+          controller.cameraController = currentCameraController;
+        }
       // case final ArcGISLocalSceneViewController controller:
       //   final currentCamera = controller.getCurrentViewpointCamera();
       //   controller.setViewpointCameraAnimated(

--- a/lib/src/compass/compass.dart
+++ b/lib/src/compass/compass.dart
@@ -91,9 +91,6 @@ class Compass extends StatefulWidget {
 class _CompassState extends State<Compass> {
   late GeoViewController _controller;
 
-  // TODO: get rid of this graphics stuff
-  final _centerPointOverlay = GraphicsOverlay();
-
   StreamSubscription<double>? _rotationSubscription;
   StreamSubscription<void>? _viewpointSubscription;
 
@@ -117,9 +114,6 @@ class _CompassState extends State<Compass> {
           setState(() => _angleDegrees = rotation);
         });
       case final ArcGISSceneViewController controller:
-        // TODO: get rid of this graphics stuff
-        controller.graphicsOverlays.add(_centerPointOverlay);
-
         _angleDegrees = controller.getCurrentViewpointCamera().heading;
         _viewpointSubscription = controller.onViewpointChanged.listen((_) {
           final heading = controller.getCurrentViewpointCamera().heading;
@@ -191,7 +185,7 @@ class _CompassState extends State<Compass> {
           // Pitch is great enough to use an orbit controller.
           // Get the target point.
           final targetPt = await _getSceneCenterPoint(context);
-          if (targetPt == null) return;
+          if (targetPt == null || targetPt.isEmpty) return;
 
           // Configure and set an OrbitLocationCameraController.
           final currentCameraController = controller.cameraController;
@@ -217,15 +211,25 @@ class _CompassState extends State<Compass> {
           // Reset the camera controller.
           controller.cameraController = currentCameraController;
         }
-      // case final ArcGISLocalSceneViewController controller:
-      //   final currentCamera = controller.getCurrentViewpointCamera();
-      //   controller.setViewpointCameraAnimated(
-      //     camera: currentCamera.rotateTo(
-      //       heading: 0,
-      //       pitch: currentCamera.pitch,
-      //       roll: currentCamera.roll,
-      //     ),
-      //   );
+      case final ArcGISLocalSceneViewController controller:
+        // Get the target point.
+        final targetPt = await _getSceneCenterPoint(context);
+        if (targetPt == null || targetPt.isEmpty) return;
+
+        final currentCamera = controller.getCurrentViewpointCamera();
+        final normalizedCurrentHeading = currentCamera.heading % 360;
+        final headingDelta = normalizedCurrentHeading < 180
+            ? -normalizedCurrentHeading
+            : 360 - normalizedCurrentHeading;
+
+        controller.setViewpointCameraAnimated(
+          camera: currentCamera.rotateAround(
+            targetPoint: targetPt,
+            deltaHeading: -headingDelta,
+            deltaPitch: 0,
+            deltaRoll: 0,
+          ),
+        );
     }
   }
 
@@ -271,20 +275,6 @@ class _CompassState extends State<Compass> {
       // This function only works with local scene view and scene view controllers.
       return null;
     }
-
-    // TODO: get rid of this graphics stuff
-    final centerPointGraphic = Graphic(
-      geometry: centerPoint,
-      symbol: SimpleMarkerSceneSymbol(
-        style: .diamond,
-        color: Colors.yellow,
-        width: 10,
-        height: 10,
-        depth: 10,
-      ),
-    );
-    _centerPointOverlay.graphics.clear();
-    _centerPointOverlay.graphics.add(centerPointGraphic);
 
     return centerPoint;
   }

--- a/lib/src/compass/compass.dart
+++ b/lib/src/compass/compass.dart
@@ -260,8 +260,9 @@ class _CompassState extends State<Compass> {
 
   Future<ArcGISPoint?> _getSceneCenterPoint(BuildContext context) async {
     // Get the center offset for the scene or local scene view
-    final renderBox = context.findRenderObject() as RenderBox?;
-    if (renderBox == null) return null;
+    // The view will exist in an ancestor of the Compass. Use the nearst ancestor's RenderBox.
+    final renderBox = context.findAncestorRenderObjectOfType<RenderBox>();
+    if (renderBox == null || !renderBox.hasSize) return null;
     final centerOffset = Offset(
       renderBox.size.width / 2,
       renderBox.size.height / 2,

--- a/lib/src/compass/compass.dart
+++ b/lib/src/compass/compass.dart
@@ -185,7 +185,17 @@ class _CompassState extends State<Compass> {
           // Pitch is great enough to use an orbit controller.
           // Get the target point.
           final targetPt = await _getSceneCenterPoint(context);
-          if (targetPt == null || targetPt.isEmpty) return;
+          if (targetPt == null || targetPt.isEmpty) {
+            // If no target point, just set the camera heading to 0 and update the view.
+            controller.setViewpointCameraAnimated(
+              camera: currentCamera.rotateTo(
+                heading: 0,
+                pitch: currentCamera.pitch,
+                roll: currentCamera.roll,
+              ),
+            );
+            return;
+          }
 
           // Configure and set an OrbitLocationCameraController.
           final currentCameraController = controller.cameraController;
@@ -215,11 +225,21 @@ class _CompassState extends State<Compass> {
           }
         }
       case final ArcGISLocalSceneViewController controller:
+        final currentCamera = controller.getCurrentViewpointCamera();
         // Get the target point.
         final targetPt = await _getSceneCenterPoint(context);
-        if (targetPt == null || targetPt.isEmpty) return;
+        if (targetPt == null || targetPt.isEmpty) {
+          // If no target point, just set the camera heading to 0 and update the view.
+          controller.setViewpointCameraAnimated(
+            camera: currentCamera.rotateTo(
+              heading: 0,
+              pitch: currentCamera.pitch,
+              roll: currentCamera.roll,
+            ),
+          );
+          return;
+        }
 
-        final currentCamera = controller.getCurrentViewpointCamera();
         final normalizedCurrentHeading = currentCamera.heading % 360;
         final headingDelta = normalizedCurrentHeading < 180
             ? -normalizedCurrentHeading


### PR DESCRIPTION
Updated the "return to north" logic of the Compass widget for SceneView and LocalSceneView to focus on the center of the view when returning to north. 

- SceneView
   - When the camera is pitched, use an OrbitLocationCameraController to orbit the camera around the center point of the view
   - When looking straight down, simply set the camera's heading to 0;
- LocalSceneView
   - LSV cannot yet use camera controllers
   - Create a copy of the current camera using `Camera.rotateAround` targeting the center point of the scene with a heading set to 0, then use `setViewpointCameraAnimated` to move the camera view.
   - There result is not a smooth as using a camera controller, but the end result is still looking at the target location.