### PR TITLE
Add public_member_api_docs linter rule

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,5 +1,9 @@
 include: linter_rules.yaml
 
+linter:
+  rules:
+    public_member_api_docs: true
+
 analyzer:
   errors:
     close_sinks: warning

--- a/lib/src/template_widget.dart
+++ b/lib/src/template_widget.dart
@@ -18,6 +18,7 @@ part of '../arcgis_maps_toolkit.dart';
 
 /// @nodoc
 class TemplateWidget extends StatelessWidget {
+  /// @nodoc
   const TemplateWidget({super.key});
 
   @override


### PR DESCRIPTION
- Adds the `public_member_api_docs` linter rule
- Addresses the only warning that emerged