### PR TITLE
update to file_picker 12.0.0

### DIFF
--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -18,6 +18,9 @@ dev_dependencies:
   flutter_test:
     sdk: flutter
 
+dependency_overrides:
+  xml: ^7.0.1
+
 flutter:
   uses-material-design: true
   assets:

--- a/lib/src/authenticator/authenticator.dart
+++ b/lib/src/authenticator/authenticator.dart
@@ -325,20 +325,18 @@ class _AuthenticatorState extends State<Authenticator>
     }
 
     // Browse for a pfx file.
-    final filePickerResult = await FilePicker.pickFiles(
+    final files = await FilePicker.pickFiles(
       type: FileType.custom,
       allowedExtensions: ['pfx'],
     );
 
-    if (filePickerResult == null ||
-        filePickerResult.files.isEmpty ||
-        !mounted) {
+    if (files.isEmpty || !mounted) {
       // If the user canceled the file picker, cancel the challenge and end here.
       challenge.cancel();
       return;
     }
 
-    final file = filePickerResult.files.single;
+    final file = files.single;
 
     // Show a dialog to prompt the user for the certificate file's password, which
     // will answer the challenge.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,7 +15,7 @@ environment:
 
 dependencies:
   arcgis_maps: ^300.2.0
-  file_picker: ^12.0.0-beta.7
+  file_picker: ^12.0.0
   fl_chart: ^1.2.0
   flutter:
     sdk: flutter
@@ -31,6 +31,9 @@ dev_dependencies:
   flutter_lints: ^6.0.0
   flutter_test:
     sdk: flutter
+
+dependency_overrides:
+  xml: ^7.0.1
 
 flutter:
   config:


### PR DESCRIPTION
Update to file_picker 12.0.0. This requires a few simple code changes.

Unfortunately, it also requires us to set a "dependency_overrides:" for the xml package. The reason is because file_picker's linux plugin requires dbus which requires xml 6.6.1, while our arcgis_maps requires xml 7.0.1. We don't care about the linux version of file_picker, so we can force it to 7.0.1 without causing problems.